### PR TITLE
feat(viewport): interactive axis orientation gizmo with orbit and sna…

### DIFF
--- a/crates/renzora/src/core/viewport_types.rs
+++ b/crates/renzora/src/core/viewport_types.rs
@@ -52,6 +52,12 @@ pub struct NavOverlayState {
     pub pan_delta_y: AtomicI32,
     /// Zoom drag delta Y (scaled by 1000 to preserve fractional part).
     pub zoom_delta_y: AtomicI32,
+    /// Whether the axis gizmo is currently being dragged (orbits).
+    pub orbit_dragging: AtomicBool,
+    /// Orbit drag delta X (scaled by 1000).
+    pub orbit_delta_x: AtomicI32,
+    /// Orbit drag delta Y (scaled by 1000).
+    pub orbit_delta_y: AtomicI32,
 }
 
 impl Default for NavOverlayState {
@@ -62,6 +68,9 @@ impl Default for NavOverlayState {
             pan_delta_x: AtomicI32::new(0),
             pan_delta_y: AtomicI32::new(0),
             zoom_delta_y: AtomicI32::new(0),
+            orbit_dragging: AtomicBool::new(false),
+            orbit_delta_x: AtomicI32::new(0),
+            orbit_delta_y: AtomicI32::new(0),
         }
     }
 }

--- a/crates/renzora_camera/src/lib.rs
+++ b/crates/renzora_camera/src/lib.rs
@@ -627,6 +627,7 @@ fn camera_controller(
 /// Apply pan/zoom from the viewport nav overlay buttons.
 fn apply_nav_overlay(
     nav: Option<Res<NavOverlayState>>,
+    settings: Res<CameraSettings>,
     pivot_lock: Res<PivotLock>,
     mut orbit: ResMut<OrbitCameraState>,
     mut camera_query: Query<&mut Transform, With<EditorCamera>>,
@@ -637,10 +638,14 @@ fn apply_nav_overlay(
     let pan_dy = nav.pan_delta_y.swap(0, std::sync::atomic::Ordering::Relaxed) as f32 / 1000.0;
     let zoom_dy = nav.zoom_delta_y.swap(0, std::sync::atomic::Ordering::Relaxed) as f32 / 1000.0;
 
+    let orbit_dx = nav.orbit_delta_x.swap(0, std::sync::atomic::Ordering::Relaxed) as f32 / 1000.0;
+    let orbit_dy = nav.orbit_delta_y.swap(0, std::sync::atomic::Ordering::Relaxed) as f32 / 1000.0;
+
     let has_pan = pan_dx != 0.0 || pan_dy != 0.0;
     let has_zoom = zoom_dy != 0.0;
+    let has_orbit = orbit_dx != 0.0 || orbit_dy != 0.0;
 
-    if !has_pan && !has_zoom {
+    if !has_pan && !has_zoom && !has_orbit {
         return;
     }
 
@@ -661,6 +666,14 @@ fn apply_nav_overlay(
         let zoom_speed = 0.02 * orbit.distance.max(0.5);
         orbit.distance -= zoom_dy * zoom_speed;
         orbit.distance = orbit.distance.clamp(0.5, 100.0);
+    }
+
+    if has_orbit {
+        let orbit_speed = settings.orbit_sensitivity * 0.01;
+        let invert_y = if settings.invert_y { -1.0 } else { 1.0 };
+        orbit.yaw -= orbit_dx * orbit_speed;
+        orbit.pitch += orbit_dy * orbit_speed * invert_y;
+        orbit.pitch = orbit.pitch.clamp(-1.5, 1.5);
     }
 
     if let Ok(mut transform) = camera_query.single_mut() {

--- a/crates/renzora_gizmo/src/lib.rs
+++ b/crates/renzora_gizmo/src/lib.rs
@@ -1668,10 +1668,11 @@ fn entity_pick_system(
     let _ = handle_state;
     // GizmoMode::None means a plugin tool is driving — skip picking.
     if *mode == GizmoMode::None { return; }
-    // Don't pick while nav overlay pan/zoom buttons are being dragged
+    // Don't pick while nav overlay buttons (pan/zoom/orbit) are being dragged
     if let Some(ref nav) = nav_overlay {
         if nav.pan_dragging.load(std::sync::atomic::Ordering::Relaxed)
             || nav.zoom_dragging.load(std::sync::atomic::Ordering::Relaxed)
+            || nav.orbit_dragging.load(std::sync::atomic::Ordering::Relaxed)
         {
             return;
         }
@@ -1748,6 +1749,7 @@ fn box_selection_system(
     if let Some(ref nav) = nav_overlay {
         if nav.pan_dragging.load(std::sync::atomic::Ordering::Relaxed)
             || nav.zoom_dragging.load(std::sync::atomic::Ordering::Relaxed)
+            || nav.orbit_dragging.load(std::sync::atomic::Ordering::Relaxed)
         {
             box_sel.active = false;
             return;

--- a/crates/renzora_viewport/src/lib.rs
+++ b/crates/renzora_viewport/src/lib.rs
@@ -408,9 +408,7 @@ impl EditorPanel for ViewportPanel {
         let play_mode = world.get_resource::<renzora::core::PlayModeState>();
         let in_play = play_mode.map_or(false, |p| p.is_in_play_mode());
         if show_axis && !in_play {
-            if let Some(orbit) = world.get_resource::<CameraOrbitSnapshot>() {
-                render_axis_gizmo(ui, orbit, rect);
-            }
+            render_axis_gizmo(ui.ctx(), world, rect);
         }
 
         // Overlay: nav pan/zoom buttons (right side, below axis gizmo)
@@ -807,10 +805,13 @@ pub(crate) const AXIS_GIZMO_SIZE: f32 = 100.0;
 pub(crate) const AXIS_GIZMO_MARGIN: f32 = 24.0; // extra margin to clear the resolution text
 
 fn render_axis_gizmo(
-    ui: &mut egui::Ui,
-    orbit: &CameraOrbitSnapshot,
+    ctx: &egui::Context,
+    world: &World,
     viewport_rect: egui::Rect,
 ) {
+    let Some(orbit) = world.get_resource::<CameraOrbitSnapshot>() else { return };
+    let Some(nav) = world.get_resource::<NavOverlayState>() else { return };
+    let Some(cmds) = world.get_resource::<renzora_editor_framework::EditorCommands>() else { return };
     let center = egui::Pos2::new(
         viewport_rect.max.x - AXIS_GIZMO_SIZE / 2.0 - AXIS_GIZMO_MARGIN,
         viewport_rect.min.y + AXIS_GIZMO_SIZE / 2.0 + AXIS_GIZMO_MARGIN,
@@ -857,41 +858,118 @@ fn render_axis_gizmo(
     // Sort back-to-front
     projected.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap());
 
-    let painter = ui.painter();
+    let gizmo_rect = egui::Rect::from_center_size(center, egui::vec2(AXIS_GIZMO_SIZE, AXIS_GIZMO_SIZE));
 
-    for &(depth, offset, color, label, _yaw, _pitch, is_positive) in &projected {
-        let end = egui::Pos2::new(center.x + offset.x, center.y + offset.y);
-
-        // Fade axes pointing away
-        let alpha = if depth < -0.1 { 100 } else { 255 };
-        let c = egui::Color32::from_rgba_unmultiplied(color.r(), color.g(), color.b(), alpha);
-
-        let line_width = if is_positive {
-            if depth < -0.1 { 2.0 } else { 3.0 }
-        } else {
-            if depth < -0.1 { 1.0 } else { 1.5 }
-        };
-
-        if is_positive {
-            painter.line_segment([center, end], egui::Stroke::new(line_width, c));
-        }
-
-        let cap_size = if is_positive { 9.0 } else { 6.0 };
-
-        if is_positive {
-            painter.circle_filled(end, cap_size, c);
-            painter.text(
-                end,
-                egui::Align2::CENTER_CENTER,
-                label,
-                egui::FontId::proportional(11.0),
-                egui::Color32::WHITE,
+    egui::Area::new(egui::Id::new("viewport_axis_gizmo"))
+        .fixed_pos(gizmo_rect.min)
+        .order(egui::Order::Foreground)
+        .show(ctx, |ui| {
+            let resp = ui.interact(
+                gizmo_rect,
+                egui::Id::new("axis_gizmo_interact"),
+                egui::Sense::click_and_drag(),
             );
-        } else {
-            painter.circle_stroke(end, cap_size, egui::Stroke::new(2.0, c));
-        }
-    }
 
-    // Center dot
-    painter.circle_filled(center, 3.0, egui::Color32::from_rgb(180, 180, 180));
+            if resp.drag_started() {
+                nav.orbit_dragging.store(true, Ordering::Relaxed);
+            }
+            if resp.drag_stopped() {
+                nav.orbit_dragging.store(false, Ordering::Relaxed);
+            }
+
+            if resp.dragged() {
+                let d = resp.drag_delta();
+                nav.orbit_delta_x.fetch_add((d.x * 1000.0) as i32, Ordering::Relaxed);
+                nav.orbit_delta_y.fetch_add((d.y * 1000.0) as i32, Ordering::Relaxed);
+            }
+
+            if resp.clicked() {
+                if let Some(pos) = resp.interact_pointer_pos() {
+                    let local_pos = pos - center;
+                    
+                    // Find closest axis endpoint
+                    let mut closest_axis = None;
+                    let mut min_dist = 15.0; // Click radius
+
+                    for &(_depth, offset, _color, _label, yaw, pitch, _is_positive) in &projected {
+                        let dist = (local_pos - offset).length();
+                        if dist < min_dist {
+                            min_dist = dist;
+                            closest_axis = Some((yaw, pitch));
+                        }
+                    }
+
+                    if let Some((yaw, pitch)) = closest_axis {
+                        cmds.push(move |w: &mut World| {
+                            if let Some(mut settings) = w.get_resource_mut::<ViewportSettings>() {
+                                settings.pending_view_angle = Some(ViewAngleCommand { yaw, pitch });
+                            }
+                        });
+                    }
+                }
+            }
+
+            if resp.hovered() {
+                ui.ctx().set_cursor_icon(egui::CursorIcon::PointingHand);
+            }
+
+            let painter = ui.painter();
+
+            // Draw background sphere highlight
+            let is_active = nav.orbit_dragging.load(Ordering::Relaxed);
+            if resp.hovered() || is_active {
+                let theme_mgr = world.get_resource::<renzora_theme::ThemeManager>();
+                let theme = theme_mgr.map(|tm| &tm.active_theme);
+                
+                let bg_color = if is_active {
+                    theme.map(|t| t.semantic.accent.to_color32().gamma_multiply(0.2))
+                        .unwrap_or(egui::Color32::from_rgba_unmultiplied(100, 100, 255, 40))
+                } else {
+                    theme.map(|t| t.widgets.hovered_bg.to_color32().gamma_multiply(0.3))
+                        .unwrap_or(egui::Color32::from_rgba_unmultiplied(255, 255, 255, 20))
+                };
+                painter.circle_filled(center, AXIS_GIZMO_SIZE / 2.0, bg_color);
+
+                if is_active {
+                    let stroke_color = theme.map(|t| t.semantic.accent.to_color32())
+                        .unwrap_or(egui::Color32::from_rgba_unmultiplied(100, 100, 255, 180));
+                    painter.circle_stroke(center, AXIS_GIZMO_SIZE / 2.0, egui::Stroke::new(1.0, stroke_color));
+                }
+            }
+
+            for &(_depth, offset, color, label, _yaw, _pitch, is_positive) in &projected {
+                let end = center + offset;
+
+                // Fade axes pointing away
+                let alpha = if _depth < -0.1 { 100 } else { 255 };
+                let c = egui::Color32::from_rgba_unmultiplied(color.r(), color.g(), color.b(), alpha);
+
+                let line_width = if is_positive {
+                    if _depth < -0.1 { 2.0 } else { 3.0 }
+                } else {
+                    if _depth < -0.1 { 1.0 } else { 1.5 }
+                };
+
+                if is_positive {
+                    painter.line_segment([center, end], egui::Stroke::new(line_width, c));
+                }
+
+                let cap_size = if is_positive { 9.0 } else { 6.0 };
+                if is_positive {
+                    painter.circle_filled(end, cap_size, c);
+                    painter.text(
+                        end,
+                        egui::Align2::CENTER_CENTER,
+                        label,
+                        egui::FontId::proportional(10.0),
+                        egui::Color32::WHITE,
+                    );
+                } else {
+                    painter.circle_stroke(end, cap_size, egui::Stroke::new(line_width, c));
+                }
+            }
+            
+            // Center dot
+            painter.circle_filled(center, 3.0, egui::Color32::from_rgb(180, 180, 180));
+        });
 }


### PR DESCRIPTION
# Interactive Viewport Axis Gizmo

We have successfully implemented interactive orbit dragging and axis snapping for the viewport orientation gizmo. This enhancement provides a more intuitive and responsive way to navigate the 3D scene, matching the interactivity of the existing navigation overlay buttons.

## Key Features

### 1. Axis Snapping
Users can now click on any of the six axis endpoints (X, Y, Z, and their negative counterparts) to immediately snap the camera to that cardinal direction. 
- **Implementation**: The gizmo detects clicks on endpoints within a 15px radius and pushes a `pending_view_angle` command to the viewport settings.

### 2. Orbit Rotation
Clicking and dragging anywhere within the gizmo's area (the background sphere) triggers camera orbit rotation.
- **Implementation**: Drag deltas are captured and stored in `NavOverlayState`. The camera system consumes these deltas to update the camera's yaw and pitch, similar to the existing pan and zoom interactions.

### 3. Visual Highlights (UX)
Added premium visual feedback to indicate when the gizmo is interactable:
- **Hover State**: A semi-transparent background sphere appears when the mouse enters the gizmo area.
- **Active State**: When dragging, the sphere becomes more prominent (using the theme's accent color) and adds a subtle stroke for better definition.
- **Pointing Hand**: The cursor changes to a pointing hand icon when hovering over the gizmo.

### 4. Input Isolation & Conflict Resolution
To prevent unintended side-effects during navigation:
- **egui::Area**: The gizmo is now wrapped in its own `egui::Area`, which ensures it correctly claims input and prevents clicks from falling through to the 3D viewport.
- **Selection Suppression**: Viewport box selection (the "blue rect") and entity picking are explicitly disabled while the user is dragging the orientation gizmo.

## Technical Summary

### Modified Components

#### [renzora](file:///Users/jv/engine/crates/renzora/src/core/viewport_types.rs)
- Added `orbit_dragging`, `orbit_delta_x`, and `orbit_delta_y` to `NavOverlayState` for thread-safe interaction tracking.

#### [renzora_camera](file:///Users/jv/engine/crates/renzora_camera/src/lib.rs)
- Updated `apply_nav_overlay` to consume the new orbit deltas and apply them to the `OrbitCameraState`.

#### [renzora_viewport](file:///Users/jv/engine/crates/renzora_viewport/src/lib.rs)
- Refactored `render_axis_gizmo` to use `egui::Area` and `Sense::click_and_drag()`.
- Implemented the projection-aware click detection for snapping and drag handling for orbiting.
- Added theme-aware rendering for the interactive background highlights.

#### [renzora_gizmo](file:///Users/jv/engine/crates/renzora_gizmo/src/lib.rs)
- Added checks to `entity_pick_system` and `box_selection_system` to ignore input when `orbit_dragging` is active.

## Verification
- **Build**: Successfully compiled using `makers run`.
- **Interaction**: Verified that dragging rotates the camera, clicking snaps to axes, and the selection rectangle no longer appears during these actions.
- **Aesthetics**: Confirmed the hover and active highlights are visually consistent with the engine's design system.
