### PR TITLE
directory drag-and-drop import capability

### DIFF
--- a/crates/renzora_import_ui/src/kinds.rs
+++ b/crates/renzora_import_ui/src/kinds.rs
@@ -17,7 +17,7 @@
 //! UI-side routing decision — model detection still delegates to
 //! `renzora_import::formats`.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 /// The category a to-be-imported file belongs to. Only [`AssetKind::Model`]
 /// needs conversion; every other variant is copied as-is.
@@ -192,6 +192,87 @@ pub fn kind_icon(path: &Path) -> (&'static str, (u8, u8, u8)) {
     }
 }
 
+/// A path queued for import, optionally carrying the source-tree subdirectory
+/// it should recreate under the destination.
+///
+/// Folder imports (Browse folder / drop a directory) fill [`relative_dir`] so
+/// `Pack/textures/a.png` lands as `<target>/Pack/textures/a.png` instead of
+/// flattening everything into `<target>/`. Single-file picks leave it empty.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct QueuedAsset {
+    pub path: PathBuf,
+    /// Forward-slashed directory under the import target (includes the selected
+    /// folder's name + any subfolders). Empty = land directly in the target.
+    /// Does **not** include the filename.
+    pub relative_dir: String,
+}
+
+impl QueuedAsset {
+    pub fn flat(path: PathBuf) -> Self {
+        Self {
+            path,
+            relative_dir: String::new(),
+        }
+    }
+}
+
+/// Collect every importable file under `path`. A single file is returned as a
+/// flat queue entry when it passes [`is_importable`]; a directory is walked
+/// recursively and every matching file keeps its path relative to that
+/// directory (including the directory's own name), so the import worker can
+/// mirror the tree under the destination.
+pub(crate) fn expand_importables(path: &Path) -> Vec<QueuedAsset> {
+    if path.is_file() {
+        return if is_importable(path) {
+            vec![QueuedAsset::flat(path.to_path_buf())]
+        } else {
+            Vec::new()
+        };
+    }
+    if !path.is_dir() {
+        return Vec::new();
+    }
+    // Include the selected folder's name so two packs don't collide when both
+    // have a top-level `textures/` — Unreal-style "import this folder as a
+    // subtree".
+    let root_name = path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("import");
+    let mut out = Vec::new();
+    let mut stack = vec![path.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let p = entry.path();
+            if p.is_dir() {
+                stack.push(p);
+            } else if is_importable(&p) {
+                let Ok(rel) = p.strip_prefix(path) else {
+                    continue;
+                };
+                let relative_dir = match rel.parent().filter(|par| !par.as_os_str().is_empty()) {
+                    Some(par) => {
+                        let sub = par.to_string_lossy().replace('\\', "/");
+                        format!("{root_name}/{sub}")
+                    }
+                    None => root_name.to_string(),
+                };
+                out.push(QueuedAsset {
+                    path: p,
+                    relative_dir,
+                });
+            }
+        }
+    }
+    // Stable order so a folder re-import queues the same way twice (read_dir
+    // order is filesystem-dependent).
+    out.sort_by(|a, b| a.path.cmp(&b.path));
+    out
+}
+
 /// Open the OS file picker filtered to everything the importer accepts. Returns
 /// the chosen paths (empty/`None` if the user cancelled). Blocking — the caller
 /// runs it on `&mut World`, same as the old model-only Browse button.
@@ -213,6 +294,22 @@ pub(crate) fn pick_importable_files() -> Option<Vec<std::path::PathBuf>> {
         .add_filter("All Files", &["*"])
         .pick_files()
         .filter(|p| !p.is_empty())
+}
+
+/// Open the OS folder picker and expand it to every importable file underneath,
+/// preserving the folder tree via [`QueuedAsset::relative_dir`]. Returns `None`
+/// if the user cancelled or the folder held nothing importable.
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) fn pick_importable_folder() -> Option<Vec<QueuedAsset>> {
+    let dir = rfd::FileDialog::new()
+        .set_title("Select folder to import")
+        .pick_folder()?;
+    let files = expand_importables(&dir);
+    if files.is_empty() {
+        None
+    } else {
+        Some(files)
+    }
 }
 
 #[cfg(test)]
@@ -285,6 +382,35 @@ mod tests {
         .unwrap();
         assert_eq!(detect_kind(&p), Some(AssetKind::Model));
         std::fs::remove_file(&p).ok();
+    }
+
+    #[test]
+    fn expand_importables_walks_folders() {
+        let root = std::env::temp_dir().join("renzora_kinds_expand_test");
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(root.join("sub")).unwrap();
+        std::fs::write(root.join("a.png"), b"x").unwrap();
+        std::fs::write(root.join("sub").join("b.glb"), b"x").unwrap();
+        std::fs::write(root.join("skip.txt"), b"x").unwrap();
+        std::fs::write(root.join("sub").join("also.wav"), b"x").unwrap();
+
+        let got = expand_importables(&root);
+        assert_eq!(got.len(), 3, "expected png+glb+wav, got {:?}", got);
+        assert!(got.iter().all(|q| is_importable(&q.path)));
+
+        let root_name = root.file_name().unwrap().to_str().unwrap();
+        let a = got.iter().find(|q| q.path.ends_with("a.png")).unwrap();
+        assert_eq!(a.relative_dir, root_name);
+        let b = got.iter().find(|q| q.path.ends_with("b.glb")).unwrap();
+        assert_eq!(b.relative_dir, format!("{root_name}/sub"));
+
+        // Single file path stays flat (no mirrored subtree).
+        let flat = expand_importables(&root.join("a.png"));
+        assert_eq!(flat.len(), 1);
+        assert!(flat[0].relative_dir.is_empty());
+        assert!(expand_importables(&root.join("skip.txt")).is_empty());
+
+        let _ = std::fs::remove_dir_all(&root);
     }
 
     #[test]

--- a/crates/renzora_import_ui/src/lib.rs
+++ b/crates/renzora_import_ui/src/lib.rs
@@ -66,7 +66,7 @@ fn collect_dropped_files(
 ) {
     use bevy::window::FileDragAndDrop;
 
-    let mut dropped: Vec<std::path::PathBuf> = Vec::new();
+    let mut dropped: Vec<crate::kinds::QueuedAsset> = Vec::new();
     let mut hover_now: Option<bool> = None;
     for ev in events.read() {
         match ev {
@@ -74,9 +74,7 @@ fn collect_dropped_files(
             FileDragAndDrop::HoveredFileCanceled { .. } => hover_now = Some(false),
             FileDragAndDrop::DroppedFile { path_buf, .. } => {
                 hover_now = Some(false);
-                if crate::kinds::is_importable(path_buf) {
-                    dropped.push(path_buf.clone());
-                }
+                dropped.extend(crate::kinds::expand_importables(path_buf));
             }
         }
     }
@@ -108,14 +106,18 @@ fn collect_dropped_files(
     }
 
     let was_empty = state.pending_files.is_empty();
-    for path in &dropped {
-        if !state.pending_files.contains(path) {
-            state.pending_files.push(path.clone());
+    for asset in dropped {
+        if !state.pending_files.iter().any(|q| q.path == asset.path) {
+            state.pending_files.push(asset);
         }
     }
     // Auto-detect unit scale from the first file.
     if was_empty && state.settings.scale == 1.0 {
-        if let Some(scale) = renzora_import::units::detect_unit_scale(&dropped[0]) {
+        if let Some(scale) = state
+            .pending_files
+            .first()
+            .and_then(|q| renzora_import::units::detect_unit_scale(&q.path))
+        {
             state.settings.scale = scale;
         }
     }
@@ -149,12 +151,9 @@ fn import_orchestrate_system(world: &mut World) {
             world.resource_mut::<overlay::ImportOverlayState>().target_directory =
                 target.0.clone();
         }
-        // New workflow: an explicit Import click opens the **OS file picker
-        // first**, then shows the overlay pre-loaded with the chosen files —
-        // rather than opening an empty overlay the user then has to Browse from.
-        // The picker is filtered to every importable kind (models + copyable
-        // assets). If the user cancels but files are already queued (e.g. from a
-        // prior drop), we still surface the overlay so those aren't stranded.
+        // Explicit Import opens the OS file picker first, then the overlay
+        // pre-loaded with the chosen files. Cancel with an empty queue leaves
+        // the overlay closed (Browse folder / drops can still fill it later).
         let picked = native::pick_and_queue_files(world);
         let has_pending = !world
             .resource::<overlay::ImportOverlayState>()

--- a/crates/renzora_import_ui/src/native.rs
+++ b/crates/renzora_import_ui/src/native.rs
@@ -66,6 +66,7 @@ pub(crate) fn register(app: &mut App) {
             manage_import_modal,
             manage_import_toast,
             file_browse_click,
+            folder_browse_click,
             dest_folder_click,
             nav_click,
             enforce_nav_section,
@@ -83,6 +84,8 @@ pub(crate) fn register(app: &mut App) {
 struct ImportRoot;
 #[derive(Component)]
 struct FileBrowseBtn;
+#[derive(Component)]
+struct FolderBrowseBtn;
 /// A clickable sidebar nav row; switches the active pane on press.
 #[derive(Component, Clone, Copy)]
 struct NavBtn(ImportSection);
@@ -408,7 +411,7 @@ fn queue_has_model(w: &Rx) -> bool {
     w.get_resource::<ImportOverlayState>().is_some_and(|s| {
         s.pending_files
             .iter()
-            .any(|p| renzora_import::formats::detect_format(p).is_some())
+            .any(|q| renzora_import::formats::detect_format(&q.path).is_some())
     })
 }
 
@@ -422,7 +425,11 @@ fn import_title(w: &Rx) -> String {
     if state.pending_files.is_empty() {
         return "Import Assets".to_string();
     }
-    let kinds: Vec<AssetKind> = state.pending_files.iter().filter_map(|p| detect_kind(p)).collect();
+    let kinds: Vec<AssetKind> = state
+        .pending_files
+        .iter()
+        .filter_map(|q| detect_kind(&q.path))
+        .collect();
     let first = kinds.first().copied();
     let uniform = first.is_some_and(|k| kinds.iter().all(|&x| x == k));
     match first.filter(|_| uniform) {
@@ -453,7 +460,7 @@ fn enforce_nav_section(state: Option<Res<ImportOverlayState>>, nav: Option<ResMu
         && !state
             .pending_files
             .iter()
-            .any(|p| renzora_import::formats::detect_format(p).is_some())
+            .any(|q| renzora_import::formats::detect_format(&q.path).is_some())
     {
         nav.active = ImportSection::Files;
     }
@@ -490,16 +497,16 @@ fn pane_header(commands: &mut Commands, fonts: &EmberFonts, title: &str, subtitl
 
 fn build_files_pane(commands: &mut Commands, fonts: &EmberFonts, parent: Entity) {
     let p = pane(commands, ImportSection::Files);
-    let head = pane_header(commands, fonts, "Files", "Add the files you want to import — models, images, audio, and more.");
+    let head = pane_header(commands, fonts, "Files", "Add files or a whole folder — models, images, audio, and more.");
 
     // Dropzone — the empty state is this panel, so there's no separate "no
-    // files" hint. Only the Browse button is clickable; the card itself is
-    // passive (real OS drag-drop is handled by the egui orchestration layer).
+    // files" hint. Only the Browse buttons are clickable; the card itself is
+    // passive (real OS drag-drop is handled by the orchestration layer).
     let dz = commands
         .spawn((
             Node {
                 width: Val::Percent(100.0),
-                height: Val::Px(116.0),
+                height: Val::Px(128.0),
                 flex_shrink: 0.0,
                 flex_direction: FlexDirection::Column,
                 align_items: AlignItems::Center,
@@ -514,10 +521,21 @@ fn build_files_pane(commands: &mut Commands, fonts: &EmberFonts, parent: Entity)
         ))
         .id();
     let cloud = icon_text(commands, &fonts.phosphor, "cloud-arrow-down", text_muted(), 30.0);
-    let dz_t = txt(commands, fonts, "Drag & drop files here", 12.0, text_primary());
-    let browse = pill_button(commands, fonts, "folder-open", "Browse files");
+    let dz_t = txt(commands, fonts, "Drag & drop files or a folder here", 12.0, text_primary());
+    let browse_row = commands
+        .spawn(Node {
+            flex_direction: FlexDirection::Row,
+            align_items: AlignItems::Center,
+            column_gap: Val::Px(8.0),
+            ..default()
+        })
+        .id();
+    let browse = pill_button(commands, fonts, "file", "Browse files");
     commands.entity(browse).insert(FileBrowseBtn);
-    commands.entity(dz).add_children(&[cloud, dz_t, browse]);
+    let browse_folder = pill_button(commands, fonts, "folder-open", "Browse folder");
+    commands.entity(browse_folder).insert(FolderBrowseBtn);
+    commands.entity(browse_row).add_children(&[browse, browse_folder]);
+    commands.entity(dz).add_children(&[cloud, dz_t, browse_row]);
 
     // Queued-file list.
     let list = commands.spawn((Node { width: Val::Percent(100.0), flex_direction: FlexDirection::Column, row_gap: Val::Px(4.0), ..default() }, FilesContainer)).id();
@@ -775,20 +793,36 @@ fn build_footer(commands: &mut Commands, fonts: &EmberFonts, panel: Entity) {
 
 fn files_snapshot(world: &Rx) -> KeyedSnapshot {
     use std::hash::{Hash, Hasher};
-    let files: Vec<PathBuf> = world.get_resource::<ImportOverlayState>().map(|s| s.pending_files.clone()).unwrap_or_default();
+    use crate::kinds::QueuedAsset;
+    let files: Vec<QueuedAsset> = world
+        .get_resource::<ImportOverlayState>()
+        .map(|s| s.pending_files.clone())
+        .unwrap_or_default();
     let items: Vec<(u64, u64)> = files
         .iter()
-        .map(|p| {
+        .map(|q| {
             let mut h = std::collections::hash_map::DefaultHasher::new();
-            p.hash(&mut h);
+            (&q.path, &q.relative_dir).hash(&mut h);
             (h.finish(), h.finish())
         })
         .collect();
-    KeyedSnapshot { items, build: Box::new(move |c, f, i| file_row(c, f, &files[i])) }
+    KeyedSnapshot {
+        items,
+        build: Box::new(move |c, f, i| file_row(c, f, &files[i])),
+    }
 }
 
-fn file_row(commands: &mut Commands, fonts: &EmberFonts, path: &std::path::Path) -> Entity {
-    let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("?").to_string();
+fn file_row(commands: &mut Commands, fonts: &EmberFonts, asset: &crate::kinds::QueuedAsset) -> Entity {
+    let path = &asset.path;
+    let name = if asset.relative_dir.is_empty() {
+        path.file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("?")
+            .to_string()
+    } else {
+        let file = path.file_name().and_then(|n| n.to_str()).unwrap_or("?");
+        format!("{}/{}", asset.relative_dir, file)
+    };
     let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("").to_uppercase();
     let row = commands
         .spawn((
@@ -880,7 +914,7 @@ fn remove_file_click(q: Query<(&Interaction, &RemoveFileBtn), Changed<Interactio
     let Some(state) = state.as_mut() else { return };
     for (i, rm) in &q {
         if *i == Interaction::Pressed {
-            state.pending_files.retain(|p| p != &rm.0);
+            state.pending_files.retain(|q| q.path != rm.0);
         }
     }
 }
@@ -891,6 +925,40 @@ fn file_browse_click(q: Query<&Interaction, (With<FileBrowseBtn>, Changed<Intera
     }
 }
 
+fn folder_browse_click(q: Query<&Interaction, (With<FolderBrowseBtn>, Changed<Interaction>)>, mut commands: Commands) {
+    if q.iter().any(|i| *i == Interaction::Pressed) {
+        commands.queue(|w: &mut World| { pick_and_queue_folder(w); });
+    }
+}
+
+/// Append queued assets, de-duping by source path and auto-detecting unit
+/// scale on a fresh queue.
+fn queue_paths(world: &mut World, assets: &[crate::kinds::QueuedAsset]) -> bool {
+    if assets.is_empty() {
+        return false;
+    }
+    let mut state = world.resource_mut::<ImportOverlayState>();
+    let was_empty = state.pending_files.is_empty();
+    let mut added = false;
+    for asset in assets {
+        if !state.pending_files.iter().any(|q| q.path == asset.path) {
+            state.pending_files.push(asset.clone());
+            added = true;
+        }
+    }
+    // Auto-detect unit scale from the first model in a fresh queue (no-op for
+    // non-model picks — `detect_unit_scale` returns None for those).
+    if was_empty && state.settings.scale == 1.0 {
+        if let Some(scale) = assets
+            .iter()
+            .find_map(|q| renzora_import::units::detect_unit_scale(&q.path))
+        {
+            state.settings.scale = scale;
+        }
+    }
+    added
+}
+
 /// Open the OS file picker (filtered to every importable kind) and append the
 /// chosen files to the queue. Returns `true` if at least one new file was added.
 /// Shared by the asset-browser Import trigger (`lib.rs`) and the overlay's own
@@ -899,23 +967,17 @@ pub(crate) fn pick_and_queue_files(world: &mut World) -> bool {
     let Some(paths) = crate::kinds::pick_importable_files() else {
         return false;
     };
-    let mut state = world.resource_mut::<ImportOverlayState>();
-    let was_empty = state.pending_files.is_empty();
-    let mut added = false;
-    for p in &paths {
-        if !state.pending_files.contains(p) {
-            state.pending_files.push(p.clone());
-            added = true;
-        }
-    }
-    // Auto-detect unit scale from the first model in a fresh queue (no-op for
-    // non-model picks — `detect_unit_scale` returns None for those).
-    if was_empty && state.settings.scale == 1.0 {
-        if let Some(scale) = paths.first().and_then(|p| renzora_import::units::detect_unit_scale(p)) {
-            state.settings.scale = scale;
-        }
-    }
-    added
+    let assets: Vec<_> = paths.into_iter().map(crate::kinds::QueuedAsset::flat).collect();
+    queue_paths(world, &assets)
+}
+
+/// Open the OS folder picker, expand it (mirroring the source tree), and
+/// append to the queue.
+pub(crate) fn pick_and_queue_folder(world: &mut World) -> bool {
+    let Some(assets) = crate::kinds::pick_importable_folder() else {
+        return false;
+    };
+    queue_paths(world, &assets)
 }
 
 /// Click a destination folder row → it becomes the import target directory.

--- a/crates/renzora_import_ui/src/overlay.rs
+++ b/crates/renzora_import_ui/src/overlay.rs
@@ -3,6 +3,7 @@
 use std::path::PathBuf;
 use std::sync::{mpsc, Mutex};
 
+use crate::kinds::QueuedAsset;
 use bevy::prelude::*;
 use renzora::core::CurrentProject;
 use renzora_import::optimize::MeshOptSettings;
@@ -75,7 +76,7 @@ pub(crate) struct ImportTask {
 #[derive(Resource)]
 pub struct ImportOverlayState {
     pub visible: bool,
-    pub pending_files: Vec<PathBuf>,
+    pub pending_files: Vec<QueuedAsset>,
     pub target_directory: String,
     /// How imported files are organized under the destination folder.
     pub layout: ImportLayout,
@@ -258,6 +259,28 @@ pub(crate) fn run_import(world: &mut World) {
     });
 }
 
+/// Join `dest` with a forward-slashed relative directory from a folder import.
+fn dest_with_rel(dest: &std::path::Path, relative_dir: &str) -> PathBuf {
+    if relative_dir.is_empty() {
+        return dest.to_path_buf();
+    }
+    relative_dir
+        .split('/')
+        .filter(|s| !s.is_empty())
+        .fold(dest.to_path_buf(), |acc, seg| acc.join(seg))
+}
+
+/// Project-relative forward-slashed prefix for a file landing under `target_dir`
+/// (plus an optional mirrored source subdirectory from a folder import).
+fn project_prefix(target_dir: &str, relative_dir: &str) -> String {
+    match (target_dir.is_empty(), relative_dir.is_empty()) {
+        (true, true) => String::new(),
+        (true, false) => relative_dir.to_string(),
+        (false, true) => target_dir.to_string(),
+        (false, false) => format!("{target_dir}/{relative_dir}"),
+    }
+}
+
 /// Pick a file path under `dest` that doesn't collide. If `name` is taken,
 /// inserts `1`, `2`, … before the extension (`tex.png` → `tex1.png`). Used by
 /// the copy path for non-model assets, which land directly in the destination
@@ -304,7 +327,7 @@ fn unique_model_dir(dest: &std::path::Path, base: &str) -> (String, PathBuf) {
 fn import_worker(
     tx: mpsc::Sender<ImportMsg>,
     project: CurrentProject,
-    files: Vec<PathBuf>,
+    files: Vec<QueuedAsset>,
     settings: ImportSettings,
     target_dir: String,
     layout: ImportLayout,
@@ -324,25 +347,41 @@ fn import_worker(
     let mut errors = Vec::new();
     let mut all_warnings = Vec::new();
 
-    for (i, source_path) in files.iter().enumerate() {
+    for (i, item) in files.iter().enumerate() {
+        let source_path = &item.path;
         let file_name = source_path
             .file_name()
             .and_then(|n| n.to_str())
             .unwrap_or("unknown")
             .to_string();
 
+        // Folder imports recreate the source tree under `dest`; single-file
+        // picks land flat in `dest` (relative_dir empty).
+        let file_dest = dest_with_rel(&dest, &item.relative_dir);
+        if let Err(e) = std::fs::create_dir_all(&file_dest) {
+            let msg = format!("failed to create folder: {}", e);
+            errors.push(format!("{}: {}", file_name, msg));
+            let _ = tx.send(ImportMsg::Log(ImportLogEntry {
+                file_name: file_name.clone(),
+                success: false,
+                message: msg,
+            }));
+            continue;
+        }
+        let target_prefix = project_prefix(&target_dir, &item.relative_dir);
+
         // Non-model assets have no conversion step. "Importing" one just copies
         // it verbatim into the destination folder the user picked — images,
         // audio, `.bsn`, `.particle`, `.material`, fonts and scripts all take
         // this path. The layout / extract / optimize options are model-only, so
-        // copies always land directly in `dest` (no per-stem subfolder).
+        // copies always land directly in `file_dest` (no per-stem subfolder).
         if renzora_import::formats::detect_format(source_path).is_none() {
             let _ = tx.send(ImportMsg::Progress {
                 current: i + 1,
                 total,
                 label: format!("Copying {}", file_name),
             });
-            let out = unique_file(&dest, &file_name);
+            let out = unique_file(&file_dest, &file_name);
             match std::fs::copy(source_path, &out) {
                 Ok(bytes) => {
                     imported += 1;
@@ -424,13 +463,14 @@ fn import_worker(
                 //     its assets stay isolated from other imports.
                 //   Combined — every file writes straight into the destination,
                 //     so derived assets merge into shared sibling folders.
+                // Both are rooted at `file_dest` (mirrors folder imports).
                 let base_stem = source_path
                     .file_stem()
                     .and_then(|s| s.to_str())
                     .unwrap_or("model");
                 let (stem_owned, model_dir) = match layout {
-                    ImportLayout::PerFileFolder => unique_model_dir(&dest, base_stem),
-                    ImportLayout::Combined => (base_stem.to_string(), dest.clone()),
+                    ImportLayout::PerFileFolder => unique_model_dir(&file_dest, base_stem),
+                    ImportLayout::Combined => (base_stem.to_string(), file_dest.clone()),
                 };
                 let stem: &str = &stem_owned;
                 if let Err(e) = std::fs::create_dir_all(&model_dir) {
@@ -456,13 +496,15 @@ fn import_worker(
                     let rewrite_uri = |uri: &Option<String>| -> Option<String> {
                         // Textures live under the model folder. Prefix the
                         // relative URI with that folder's path from the project
-                        // root so consumers can resolve it. The model folder is
-                        // `<target>/<stem>/` (PerFileFolder) or `<target>/`
-                        // (Combined).
+                        // root so consumers can resolve it.
                         let prefix = match layout {
-                            ImportLayout::PerFileFolder if target_dir.is_empty() => stem.to_string(),
-                            ImportLayout::PerFileFolder => format!("{}/{}", target_dir, stem),
-                            ImportLayout::Combined => target_dir.clone(),
+                            ImportLayout::PerFileFolder if target_prefix.is_empty() => {
+                                stem.to_string()
+                            }
+                            ImportLayout::PerFileFolder => {
+                                format!("{}/{}", target_prefix, stem)
+                            }
+                            ImportLayout::Combined => target_prefix.clone(),
                         };
                         uri.as_ref().map(|u| {
                             if prefix.is_empty() {
@@ -658,8 +700,8 @@ fn import_worker(
                     .and_then(|s| s.to_str())
                     .unwrap_or("model");
                 let (stem_owned, fallback_model_dir) = match layout {
-                    ImportLayout::PerFileFolder => unique_model_dir(&dest, base_stem),
-                    ImportLayout::Combined => (base_stem.to_string(), dest.clone()),
+                    ImportLayout::PerFileFolder => unique_model_dir(&file_dest, base_stem),
+                    ImportLayout::Combined => (base_stem.to_string(), file_dest.clone()),
                 };
                 let _stem: &str = &stem_owned;
                 let anim_dir = fallback_model_dir.join("animations");

--- a/docs/r1-alpha7/engine-core/asset-pipeline.md
+++ b/docs/r1-alpha7/engine-core/asset-pipeline.md
@@ -130,10 +130,16 @@ buckets, decided by `renzora_import_ui::kinds::detect_kind`:
 
 **Workflow.** Clicking the asset browser's **Import** button (or **☰ → File →
 Import Assets…** in the top bar, or the command palette's *File: Import…*)
-opens the **OS file picker first**, filtered to every
-importable kind. Once files are chosen, the modal appears pre-loaded with them —
-there's no separate "open empty modal, then Browse" step. (Drag-and-drop still
-works too, and honours the same kind filter.)
+opens the **OS file picker first**, filtered to every importable kind. Once
+files are chosen, the modal appears pre-loaded with them. Cancelling an empty
+picker leaves the modal closed.
+
+OS dialogs can't pick files and folders in one shot. To import a whole directory,
+use **Browse folder** on the Files pane or **drag a folder** onto the asset
+browser — both expand through the same detector, **preserve the source folder
+tree** under the destination (including the selected folder's name), and land
+in the batch queue. Drag-and-drop of individual files still works too (flat into
+the target).
 
 It's a **two-pane dialog**: a left sidebar lists the sections and a right pane
 shows the active one, so the modal stays a fixed size instead of scrolling
@@ -141,9 +147,9 @@ through every option at once. The modal always opens on **Files**, and its title
 tracks the queue's kind (*Import 3D Models* / *Import Images* / … / the generic
 *Import Assets* for an empty or mixed queue).
 
-- **Files** — a drag-and-drop card (a **Browse files** button re-opens the
-  picker) above the queued-file list. Each row's icon reflects the file's kind.
-  The sidebar's Files row carries a count badge of how many files are queued.
+- **Files** — a drag-and-drop card (**Browse files** / **Browse folder**) above
+  the queued-file list. Each row's icon reflects the file's kind. The sidebar's
+  Files row carries a count badge of how many files are queued.
 - **Settings** — scale, up-axis, **Flip UVs** and **Generate normals** as
   label-left / control-right rows, fed into `ImportSettings`. *Model-only: the
   nav row hides when the queue has no model.*


### PR DESCRIPTION
## Summary

Directory import support with protecting their relative locations in the imported directory.
For example, if you import this directory, the importer will create directories and folders with respecting their locations.
<img width="402" height="53" alt="image" src="https://github.com/user-attachments/assets/cdfdc1bf-bbae-44ae-931f-72262a4df656" />

<img width="267" height="393" alt="image" src="https://github.com/user-attachments/assets/c013251b-e561-445f-bd9a-2457962aa781" />


## Changes

-
-
-

## Related Issues

Closes #

## Checklist

- [x] Code compiles cleanly (`renzora check`)
- [ ] All existing tests pass (`renzora test`) (My pc stucked when its working, so i couldnt complete it)
- [ ] New tests added (if applicable)
- [ ] No unrelated formatting or refactoring changes
- [ ] Branch is up to date with `main`

## Testing

How did you verify this works? Steps to test, screenshots, or test output.

## Screenshots

(If applicable — UI changes, rendering changes, etc.)
