### PR TITLE
Feat/node error attribution

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -158,10 +158,16 @@ rustflags = [
 
 # Linux: mold linker + $ORIGIN rpath so the binary finds bevy_dylib,
 # renzora.so, and any dlopen'd distribution plugin next to itself.
+#
+# `-fuse-ld=mold`, never the absolute `/usr/bin/mold`: clang has rejected a path
+# in -fuse-ld since 12 ("invalid linker name in argument"), and on a NixOS host
+# there is no /usr/bin/mold to name anyway. The name resolves through PATH in
+# the container and on the host alike. docker/linux/Dockerfile's cross wrapper
+# strips this exact string.
 [target.x86_64-unknown-linux-gnu]
 linker = "clang"
 rustflags = [
-    "-C", "link-arg=-fuse-ld=/usr/bin/mold",
+    "-C", "link-arg=-fuse-ld=mold",
     "-C", "link-arg=-Wl,-rpath,$ORIGIN",
     "--remap-path-prefix=/usr/local/cargo=/cargo",
     "--remap-path-prefix=/app/src=/renzora",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7462,7 +7462,6 @@ name = "renzora_clouds"
 version = "0.1.0"
 dependencies = [
  "bevy",
- "naga",
  "renzora",
  "serde",
 ]
@@ -8855,7 +8854,6 @@ version = "0.1.0"
 dependencies = [
  "bevy",
  "bytemuck",
- "naga",
  "png 0.17.16",
  "renzora",
  "renzora_physics",
@@ -9085,7 +9083,6 @@ version = "0.1.0"
 dependencies = [
  "avian3d",
  "bevy",
- "naga",
  "renzora",
  "serde",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8651,6 +8651,7 @@ dependencies = [
  "naga",
  "naga_oil",
  "renzora",
+ "renzora_shader",
  "renzora_test_harness",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1293,7 +1293,7 @@ dependencies = [
  "bytemuck",
  "fixedbitset",
  "futures",
- "naga 29.0.3",
+ "naga",
  "naga_oil",
  "rand 0.10.1",
  "rand_pcg",
@@ -1977,7 +1977,7 @@ dependencies = [
  "indexmap",
  "itertools 0.14.0",
  "js-sys",
- "naga 29.0.3",
+ "naga",
  "nonmax",
  "offset-allocator",
  "profiling",
@@ -2049,7 +2049,7 @@ dependencies = [
  "bevy_platform 0.19.1",
  "bevy_reflect 0.19.1",
  "bevy_utils 0.19.1",
- "naga 29.0.3",
+ "naga",
  "naga_oil",
  "serde",
  "thiserror 2.0.18",
@@ -2526,27 +2526,12 @@ dependencies = [
 
 [[package]]
 name = "bit-set"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
-dependencies = [
- "bit-vec 0.8.0",
-]
-
-[[package]]
-name = "bit-set"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34ddef2995421ab6a5c779542c81ee77c115206f4ad9d5a8e05f4ff49716a3dd"
 dependencies = [
- "bit-vec 0.9.1",
+ "bit-vec",
 ]
-
-[[package]]
-name = "bit-vec"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bit-vec"
@@ -5459,38 +5444,12 @@ dependencies = [
 
 [[package]]
 name = "naga"
-version = "27.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "066cf25f0e8b11ee0df221219010f213ad429855f57c494f995590c861a9a7d8"
-dependencies = [
- "arrayvec",
- "bit-set 0.8.0",
- "bitflags 2.11.1",
- "cfg-if",
- "cfg_aliases",
- "codespan-reporting 0.12.0",
- "half",
- "hashbrown 0.16.1",
- "hexf-parse",
- "indexmap",
- "libm",
- "log",
- "num-traits",
- "once_cell",
- "pp-rs",
- "rustc-hash",
- "thiserror 2.0.18",
- "unicode-ident",
-]
-
-[[package]]
-name = "naga"
 version = "29.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dd91265cc2454558f659b3b4b9640f0ddb8cc6521277f166b8a8c181c898079"
 dependencies = [
  "arrayvec",
- "bit-set 0.9.1",
+ "bit-set",
  "bitflags 2.11.1",
  "cfg-if",
  "cfg_aliases",
@@ -5519,7 +5478,7 @@ dependencies = [
  "codespan-reporting 0.12.0",
  "data-encoding",
  "indexmap",
- "naga 29.0.3",
+ "naga",
  "regex",
  "rustc-hash",
  "thiserror 2.0.18",
@@ -7219,7 +7178,7 @@ name = "renzora"
 version = "0.1.0"
 dependencies = [
  "bevy",
- "naga 27.0.3",
+ "naga",
  "renzora_macros",
  "ron 0.8.1",
  "serde",
@@ -7503,7 +7462,7 @@ name = "renzora_clouds"
 version = "0.1.0"
 dependencies = [
  "bevy",
- "naga 29.0.3",
+ "naga",
  "renzora",
  "serde",
 ]
@@ -8471,7 +8430,7 @@ name = "renzora_postprocess"
 version = "0.1.0"
 dependencies = [
  "bevy",
- "naga 27.0.3",
+ "naga",
  "renzora",
  "renzora_plugin",
 ]
@@ -8690,8 +8649,10 @@ name = "renzora_shader"
 version = "0.1.0"
 dependencies = [
  "bevy",
- "naga 27.0.3",
+ "naga",
+ "naga_oil",
  "renzora",
+ "renzora_test_harness",
  "serde",
  "serde_json",
  "uuid",
@@ -8894,7 +8855,7 @@ version = "0.1.0"
 dependencies = [
  "bevy",
  "bytemuck",
- "naga 29.0.3",
+ "naga",
  "png 0.17.16",
  "renzora",
  "renzora_physics",
@@ -9124,7 +9085,7 @@ version = "0.1.0"
 dependencies = [
  "avian3d",
  "bevy",
- "naga 29.0.3",
+ "naga",
  "renzora",
  "serde",
 ]
@@ -11024,7 +10985,7 @@ dependencies = [
  "hashbrown 0.16.1",
  "js-sys",
  "log",
- "naga 29.0.3",
+ "naga",
  "parking_lot",
  "portable-atomic",
  "profiling",
@@ -11046,8 +11007,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02da3ad1b568337f25513b317870960ef87073ea0945502e44b864b67a8c77b7"
 dependencies = [
  "arrayvec",
- "bit-set 0.9.1",
- "bit-vec 0.9.1",
+ "bit-set",
+ "bit-vec",
  "bitflags 2.11.1",
  "bytemuck",
  "cfg_aliases",
@@ -11055,7 +11016,7 @@ dependencies = [
  "hashbrown 0.16.1",
  "indexmap",
  "log",
- "naga 29.0.3",
+ "naga",
  "once_cell",
  "parking_lot",
  "portable-atomic",
@@ -11118,7 +11079,7 @@ dependencies = [
  "android_system_properties",
  "arrayvec",
  "ash",
- "bit-set 0.9.1",
+ "bit-set",
  "bitflags 2.11.1",
  "block2 0.6.2",
  "bytemuck",
@@ -11134,7 +11095,7 @@ dependencies = [
  "libc",
  "libloading 0.8.9",
  "log",
- "naga 29.0.3",
+ "naga",
  "ndk-sys",
  "objc2 0.6.4",
  "objc2-core-foundation",
@@ -11169,7 +11130,7 @@ version = "29.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59c654c483f058800972c3645e95388a7eca31bf9fe1933bc20e036588a0be02"
 dependencies = [
- "naga 29.0.3",
+ "naga",
  "wgpu-types 29.0.3",
 ]
 

--- a/coverage-floors.txt
+++ b/coverage-floors.txt
@@ -111,7 +111,7 @@ renzora_scene 6.0
 renzora_scripting 17.7
 renzora_scripting_editor 0.0
 renzora_settings 4.5
-renzora_shader 14.1
+renzora_shader 66.2
 renzora_shader_editor 0.0
 renzora_shape_library 84.2
 renzora_shell 0.0

--- a/crates/renzora/Cargo.toml
+++ b/crates/renzora/Cargo.toml
@@ -63,7 +63,7 @@ serde = { version = "1", features = ["derive"] }
 toml = "0.8"
 ron = "0.8"
 # NOT a real dependency — a transitive-feature fix. naga is already pulled in by
-# `bevy_render` → `wgpu` → `naga 27`. On Bevy 0.19, wgpu-core does NOT enable
+# `bevy_render` → `wgpu` → `naga 29`. On Bevy 0.19, wgpu-core does NOT enable
 # naga's own `termcolor` feature, but `codespan-reporting` ends up with ITS
 # `termcolor` feature on (its default). naga's error code then takes the
 # `not(termcolor)` branch (a `String` diagnostic buffer) and hands it to
@@ -73,7 +73,7 @@ ron = "0.8"
 # `renzora` is the universal dependency) aligns the two: naga then uses
 # `NoColor<Vec<u8>>`, which IS `WriteColor`. No cycle risk — naga is a leaf
 # render dep, not a `renzora_*` crate. Remove if a future wgpu enables it.
-naga = { version = "27", features = ["termcolor"] }
+naga = { version = "29", features = ["termcolor"] }
 # Editor-contract derive/attribute macros (`Inspectable`, `post_process`),
 # re-exported from core under the `editor` feature. Proc-macro crate with no
 # runtime weight and no cycle (it depends only on syn/quote, never on renzora).

--- a/crates/renzora/Cargo.toml
+++ b/crates/renzora/Cargo.toml
@@ -73,7 +73,9 @@ ron = "0.8"
 # `renzora` is the universal dependency) aligns the two: naga then uses
 # `NoColor<Vec<u8>>`, which IS `WriteColor`. No cycle risk — naga is a leaf
 # render dep, not a `renzora_*` crate. Remove if a future wgpu enables it.
-naga = { version = "29", features = ["termcolor"] }
+# `wgsl-in` is the real one: `wgsl.rs` parses and validates self-contained
+# shaders here so no other crate re-rolls it.
+naga = { version = "29", features = ["termcolor", "wgsl-in"] }
 # Editor-contract derive/attribute macros (`Inspectable`, `post_process`),
 # re-exported from core under the `editor` feature. Proc-macro crate with no
 # runtime weight and no cycle (it depends only on syn/quote, never on renzora).

--- a/crates/renzora/src/content_problems.rs
+++ b/crates/renzora/src/content_problems.rs
@@ -1,0 +1,155 @@
+//! Problems with authored content, keyed by the file they are in — per-file and
+//! replaced on recompile, unlike [`crate::runtime_warnings`]' time-ordered log.
+
+use std::collections::BTreeMap;
+
+use bevy::prelude::*;
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum ProblemSeverity {
+    Warning,
+    Error,
+}
+
+#[derive(Clone, Debug)]
+pub struct ContentProblem {
+    pub severity: ProblemSeverity,
+    /// What went wrong, in the compiler's own words.
+    pub message: String,
+    /// Line in the *generated* shader, where the producer can place one. A
+    /// graph has no lines of its own, so this is usually `None`.
+    pub line: Option<usize>,
+}
+
+/// Problems by source path, project-relative.
+///
+/// `BTreeMap` so the panel's row order is the same every frame — a `HashMap`
+/// reshuffles the list on each rebuild.
+#[derive(Resource, Default, Debug)]
+pub struct ContentProblems {
+    by_path: BTreeMap<String, Vec<ContentProblem>>,
+}
+
+impl ContentProblems {
+    /// Replace everything known about `path`. An empty `problems` clears it, so
+    /// a producer can call this unconditionally after every compile.
+    pub fn set(&mut self, path: impl Into<String>, problems: Vec<ContentProblem>) {
+        let path = path.into();
+        if problems.is_empty() {
+            self.by_path.remove(&path);
+        } else {
+            self.by_path.insert(path, problems);
+        }
+    }
+
+    /// Replace only the rows of one severity for `path`, keeping the rest.
+    ///
+    /// Producers own a severity each — the resolver's validator owns errors,
+    /// compile sites own warnings — and neither may clobber the other. Every
+    /// entry in `problems` is tagged `severity` by the caller.
+    pub fn set_severity(
+        &mut self,
+        path: impl Into<String>,
+        severity: ProblemSeverity,
+        mut problems: Vec<ContentProblem>,
+    ) {
+        let path = path.into();
+        let mut kept = self.by_path.remove(&path).unwrap_or_default();
+        kept.retain(|p| p.severity != severity);
+        kept.append(&mut problems);
+        self.set(path, kept);
+    }
+
+    pub fn clear_path(&mut self, path: &str) {
+        self.by_path.remove(path);
+    }
+
+    pub fn get(&self, path: &str) -> &[ContentProblem] {
+        self.by_path.get(path).map_or(&[], Vec::as_slice)
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.by_path.is_empty()
+    }
+
+    /// `(path, problem)` pairs in path order, errors before warnings within a
+    /// path.
+    pub fn iter(&self) -> impl Iterator<Item = (&str, &ContentProblem)> {
+        self.by_path
+            .iter()
+            .flat_map(|(path, list)| list.iter().map(move |p| (path.as_str(), p)))
+    }
+
+    pub fn error_count(&self) -> usize {
+        self.iter()
+            .filter(|(_, p)| p.severity == ProblemSeverity::Error)
+            .count()
+    }
+
+    pub fn warning_count(&self) -> usize {
+        self.iter()
+            .filter(|(_, p)| p.severity == ProblemSeverity::Warning)
+            .count()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn err(message: &str) -> ContentProblem {
+        ContentProblem {
+            severity: ProblemSeverity::Error,
+            message: message.to_string(),
+            line: None,
+        }
+    }
+
+    /// The panel must show a repaired file as fixed. `set` replaces rather than
+    /// appends, so recompiling clean is what clears it.
+    #[test]
+    fn recompiling_clean_clears_the_path() {
+        let mut problems = ContentProblems::default();
+        problems.set("materials/a.material", vec![err("boom")]);
+        assert_eq!(problems.error_count(), 1);
+
+        problems.set("materials/a.material", Vec::new());
+        assert!(problems.is_empty());
+    }
+
+    #[test]
+    fn one_path_does_not_clear_another() {
+        let mut problems = ContentProblems::default();
+        problems.set("a.material", vec![err("a broke")]);
+        problems.set("b.material", vec![err("b broke")]);
+        problems.set("a.material", Vec::new());
+
+        assert_eq!(problems.get("a.material").len(), 0);
+        assert_eq!(problems.get("b.material").len(), 1);
+    }
+
+    /// Two producers share a path: the validator replaces errors, the compile
+    /// site replaces warnings, and neither disturbs the other severity.
+    #[test]
+    fn severities_are_replaced_independently() {
+        let mut problems = ContentProblems::default();
+        problems.set(
+            "a.material",
+            vec![
+                err("broke"),
+                ContentProblem {
+                    severity: ProblemSeverity::Warning,
+                    message: "risky".to_string(),
+                    line: None,
+                },
+            ],
+        );
+
+        problems.set_severity("a.material", ProblemSeverity::Error, Vec::new());
+        assert_eq!(problems.error_count(), 0);
+        assert_eq!(problems.warning_count(), 1, "the warning is not the validator's to clear");
+
+        problems.set_severity("a.material", ProblemSeverity::Warning, Vec::new());
+        assert!(problems.is_empty());
+    }
+}

--- a/crates/renzora/src/content_problems.rs
+++ b/crates/renzora/src/content_problems.rs
@@ -19,6 +19,9 @@ pub struct ContentProblem {
     /// Line in the *generated* shader, where the producer can place one. A
     /// graph has no lines of its own, so this is usually `None`.
     pub line: Option<usize>,
+    /// Node in the material graph the error belongs to, where the producer
+    /// can attribute one. The graph editor marks these nodes.
+    pub node_id: Option<u64>,
 }
 
 /// Problems by source path, project-relative.
@@ -102,6 +105,7 @@ mod tests {
             severity: ProblemSeverity::Error,
             message: message.to_string(),
             line: None,
+            node_id: None,
         }
     }
 
@@ -141,6 +145,7 @@ mod tests {
                     severity: ProblemSeverity::Warning,
                     message: "risky".to_string(),
                     line: None,
+                    node_id: None,
                 },
             ],
         );

--- a/crates/renzora/src/lib.rs
+++ b/crates/renzora/src/lib.rs
@@ -104,6 +104,9 @@ pub mod runtime_warnings;
 // resolver) and the reader (the code editor) must agree on one definition.
 pub mod content_problems;
 
+// The one WGSL↔naga seam (parse/validate) for self-contained shaders.
+pub mod wgsl;
+
 // ── Editor contract (Operation Merge fold) ───────────────────────────────
 // The thin editor types shared across the binary↔bundle boundary live here in
 // the one shared `renzora` dylib (so `EditorSelection` et al. unify to one

--- a/crates/renzora/src/lib.rs
+++ b/crates/renzora/src/lib.rs
@@ -99,6 +99,11 @@ pub mod postprocess;
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
 pub mod runtime_warnings;
 
+// Per-file problems with authored content, behind the editor's Problems panel.
+// Here rather than in a plugin crate because the producer (the material
+// resolver) and the reader (the code editor) must agree on one definition.
+pub mod content_problems;
+
 // ── Editor contract (Operation Merge fold) ───────────────────────────────
 // The thin editor types shared across the binary↔bundle boundary live here in
 // the one shared `renzora` dylib (so `EditorSelection` et al. unify to one

--- a/crates/renzora/src/wgsl.rs
+++ b/crates/renzora/src/wgsl.rs
@@ -1,0 +1,51 @@
+//! The one place WGSL meets naga in this workspace.
+//!
+//! Self-contained sources only — a shader using `#import` is naga_oil
+//! preprocessing, not WGSL, and belongs to a composer (the material
+//! validator in `renzora_shader` keeps one).
+
+use naga::front::wgsl::ParseError;
+use naga::valid::{Capabilities, ModuleInfo, ValidationError, ValidationFlags, Validator};
+use naga::{Module, WithSpan};
+
+/// Parse self-contained WGSL into a naga module.
+pub fn parse(source: &str) -> Result<Module, ParseError> {
+    naga::front::wgsl::parse_str(source)
+}
+
+/// Validate a module the way wgpu will. The flags and capabilities live here
+/// so no call site decides them alone — four of them once did, identically.
+///
+/// The error comes boxed: naga's `WithSpan` carries the whole codespan, and an
+/// Err that fat costs every caller a `result_large_err` warning.
+pub fn validate(module: &Module) -> Result<ModuleInfo, Box<WithSpan<ValidationError>>> {
+    Validator::new(ValidationFlags::all(), Capabilities::all())
+        .validate(module)
+        .map_err(Box::new)
+}
+
+/// [`parse`] + [`validate`], with the compiler's own rendering against
+/// `source`. The common case for a test that only cares pass/fail.
+pub fn check(source: &str) -> Result<Module, String> {
+    let module = parse(source).map_err(|err| err.emit_to_string(source))?;
+    validate(&module).map_err(|err| err.emit_to_string(source))?;
+    Ok(module)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_valid_module_checks() {
+        check("@vertex fn vertex() -> @builtin(position) vec4<f32> { return vec4<f32>(0.0); }")
+            .expect("a minimal vertex shader must pass");
+    }
+
+    #[test]
+    fn an_invalid_module_names_the_problem() {
+        let err = check("fn f() -> f32 { return no_such_symbol; }")
+            .expect_err("an undeclared symbol must fail");
+        assert!(err.contains("no_such_symbol"), "got: {err}");
+    }
+}

--- a/crates/renzora_blueprint_editor/src/native_graph.rs
+++ b/crates/renzora_blueprint_editor/src/native_graph.rs
@@ -221,8 +221,10 @@ fn tool_button<M: Component>(commands: &mut Commands, fonts: &EmberFonts, icon: 
 
 // ── Snapshots ──────────────────────────────────────────────────────────────────
 
-type Port = (String, String, (u8, u8, u8));
+type Port = (String, String, (u8, u8, u8), u32);
 /// Neutral port colour for blueprint pins (material pins are typed/coloured).
+/// Blueprint pins are untyped, so they all share compat group 0 — any pin
+/// connects to any pin, as before the widget grouped ports.
 const BP_PORT: (u8, u8, u8) = (140, 150, 175);
 
 /// Per-input data for the inline editors: (pin template, is-connected). Aligned
@@ -241,8 +243,8 @@ fn node_snapshot(world: &Rx, canvas: Entity, viewport: Entity) -> KeyedSnapshot 
                 let title = def.map(|d| d.display_name.to_string()).unwrap_or_else(|| n.node_type.clone());
                 let color = def.map(|d| (d.color[0], d.color[1], d.color[2])).unwrap_or((90, 90, 100));
                 let pins = def.map(|d| (d.pins)()).unwrap_or_default();
-                let inputs: Vec<Port> = pins.iter().filter(|p| p.direction == PinDir::Input).map(|p| (p.name.clone(), p.label.clone(), BP_PORT)).collect();
-                let outputs: Vec<Port> = pins.iter().filter(|p| p.direction == PinDir::Output).map(|p| (p.name.clone(), p.label.clone(), BP_PORT)).collect();
+                let inputs: Vec<Port> = pins.iter().filter(|p| p.direction == PinDir::Input).map(|p| (p.name.clone(), p.label.clone(), BP_PORT, 0)).collect();
+                let outputs: Vec<Port> = pins.iter().filter(|p| p.direction == PinDir::Output).map(|p| (p.name.clone(), p.label.clone(), BP_PORT, 0)).collect();
                 // Aligned with `inputs`: clone the template + whether a wire feeds it.
                 let in_specs: Vec<InputSpec> = pins
                     .iter()

--- a/crates/renzora_clouds/Cargo.toml
+++ b/crates/renzora_clouds/Cargo.toml
@@ -11,11 +11,5 @@ bevy = { workspace = true }
 renzora = { path = "../renzora", default-features = false }
 serde = { version = "1", features = ["derive"] }
 
-[dev-dependencies]
-# Compiles the WGSL in a unit test. A shader error otherwise surfaces only as a
-# pipeline that never becomes ready — the sky simply stays empty, with the reason
-# buried in the log. Same version wgpu uses, so validation matches load time.
-naga = { version = "29", features = ["wgsl-in"] }
-
 [lints]
 workspace = true

--- a/crates/renzora_clouds/src/lib.rs
+++ b/crates/renzora_clouds/src/lib.rs
@@ -852,15 +852,7 @@ mod tests {
 
     /// Compile a WGSL module exactly as wgpu will.
     fn validate(name: &str, source: &str) {
-        let module = naga::front::wgsl::parse_str(source)
-            .unwrap_or_else(|err| panic!("{name}: {}", err.emit_to_string(source)));
-        let mut validator = naga::valid::Validator::new(
-            naga::valid::ValidationFlags::all(),
-            naga::valid::Capabilities::all(),
-        );
-        if let Err(err) = validator.validate(&module) {
-            panic!("{name}: {}", err.emit_to_string(source));
-        }
+        renzora::wgsl::check(source).unwrap_or_else(|err| panic!("{name}: {err}"));
     }
 
     /// Reads a `const NAME: f32 = ...;` out of the shader. Handles a bare literal

--- a/crates/renzora_code_editor/src/native_problems.rs
+++ b/crates/renzora_code_editor/src/native_problems.rs
@@ -1,7 +1,6 @@
-//! Bevy-native (ember) Problems panel — aggregates `ScriptError`s across every
-//! open editor tab. Clicking a row switches to that file and jumps to the error
-//! line (writes `active_tab` + `pending_goto_line`). Mirrors the egui
-//! `ProblemsPanel`.
+//! Bevy-native (ember) Problems panel — `ScriptError`s from every open editor
+//! tab, plus [`ContentProblems`], which files nobody has open report into.
+//! Clicking a row jumps to it, when it belongs to an open tab.
 
 use std::hash::{Hash, Hasher};
 
@@ -15,12 +14,28 @@ use renzora_ember::reactive::Rx;
 use renzora_ember::reactive::tracked::{bind_display, keyed_list};
 use renzora_ember::theme::*;
 
+use renzora::content_problems::{ContentProblems, ProblemSeverity};
+
 use crate::state::CodeEditorState;
 
 #[derive(Component)]
 struct ProblemRow {
-    file_idx: usize,
+    /// `None` when the reporting file is not open in a tab.
+    file_idx: Option<usize>,
     line: usize,
+}
+
+/// One panel row, from either source.
+#[derive(Clone, Hash)]
+struct Row {
+    file_idx: Option<usize>,
+    /// Shown under the message; a file name for a tab, a project-relative path
+    /// for a content problem.
+    location: String,
+    message: String,
+    line: Option<usize>,
+    column: Option<usize>,
+    is_error: bool,
 }
 
 pub fn register_native_problems(app: &mut App) {
@@ -30,6 +45,18 @@ pub fn register_native_problems(app: &mut App) {
 
 fn has_problems(w: &Rx) -> bool {
     w.get_resource::<CodeEditorState>().is_some_and(|s| s.open_files.iter().any(|f| f.error.is_some()))
+        || w.get_resource::<ContentProblems>().is_some_and(|p| !p.is_empty())
+}
+
+/// Which open tab, if any, a content problem's project-relative path belongs to.
+///
+/// `Path::ends_with` matches whole components, so `mat.material` cannot claim
+/// `other_mat.material`.
+fn open_tab_for(state: Option<&CodeEditorState>, rel: &str) -> Option<usize> {
+    state?
+        .open_files
+        .iter()
+        .position(|f| f.path.ends_with(rel))
 }
 
 fn build(commands: &mut Commands, fonts: &EmberFonts) -> Entity {
@@ -57,45 +84,70 @@ fn build(commands: &mut Commands, fonts: &EmberFonts) -> Entity {
 }
 
 fn problems_snapshot(world: &Rx) -> KeyedSnapshot {
-    let Some(state) = world.get_resource::<CodeEditorState>() else { return empty() };
-    // (file_idx, file_name, message first line, line, col)
-    let problems: Vec<(usize, String, String, Option<usize>, Option<usize>)> = state
-        .open_files
+    let state = world.get_resource::<CodeEditorState>();
+    let mut rows: Vec<Row> = Vec::new();
+
+    if let Some(state) = state.as_ref() {
+        for (idx, file) in state.open_files.iter().enumerate() {
+            let Some(error) = file.error.as_ref() else { continue };
+            rows.push(Row {
+                file_idx: Some(idx),
+                location: file.name.clone(),
+                message: error.message.lines().next().unwrap_or_default().to_string(),
+                line: error.line,
+                column: error.column,
+                is_error: true,
+            });
+        }
+    }
+
+    if let Some(problems) = world.get_resource::<ContentProblems>() {
+        for (path, problem) in problems.iter() {
+            rows.push(Row {
+                file_idx: open_tab_for(state, path),
+                location: path.to_string(),
+                message: problem.message.lines().next().unwrap_or_default().to_string(),
+                line: problem.line,
+                column: None,
+                is_error: problem.severity == ProblemSeverity::Error,
+            });
+        }
+    }
+
+    if rows.is_empty() {
+        return empty();
+    }
+
+    let items: Vec<(u64, u64)> = rows
         .iter()
         .enumerate()
-        .filter_map(|(idx, f)| {
-            f.error.as_ref().map(|e| (idx, f.name.clone(), e.message.lines().next().unwrap_or("").to_string(), e.line, e.column))
-        })
-        .collect();
-    let items: Vec<(u64, u64)> = problems
-        .iter()
-        .map(|(idx, name, msg, line, col)| {
+        .map(|(i, row)| {
             let mut k = hasher();
-            idx.hash(&mut k);
+            (i, &row.location).hash(&mut k);
             let mut h = hasher();
-            (name, msg, line, col).hash(&mut h);
+            row.hash(&mut h);
             (k.finish(), h.finish())
         })
         .collect();
     KeyedSnapshot {
         items,
-        build: Box::new(move |c, f, i| {
-            let (idx, name, msg, line, col) = &problems[i];
-            problem_row(c, f, *idx, name, msg, *line, *col)
-        }),
+        build: Box::new(move |c, f, i| problem_row(c, f, &rows[i])),
     }
 }
 
-fn problem_row(commands: &mut Commands, fonts: &EmberFonts, file_idx: usize, name: &str, msg: &str, line: Option<usize>, col: Option<usize>) -> Entity {
+fn problem_row(commands: &mut Commands, fonts: &EmberFonts, item: &Row) -> Entity {
+    let Row { file_idx, location: name, message: msg, line, column: col, is_error } = item;
+    let (line, col) = (*line, *col);
     let row = commands
         .spawn((
             Node { width: Val::Percent(100.0), min_height: Val::Px(32.0), flex_direction: FlexDirection::Row, align_items: AlignItems::Center, column_gap: Val::Px(8.0), padding: UiRect::axes(Val::Px(10.0), Val::Px(4.0)), ..default() },
             BackgroundColor(Color::NONE),
             Interaction::default(),
-            ProblemRow { file_idx, line: line.unwrap_or(1).max(1) },
+            ProblemRow { file_idx: *file_idx, line: line.unwrap_or(1).max(1) },
         ))
         .id();
-    let icon = icon_text(commands, &fonts.phosphor, "warning", close_red(), 14.0);
+    let (glyph, tint) = if *is_error { ("warning", close_red()) } else { ("warning-circle", warn_amber()) };
+    let icon = icon_text(commands, &fonts.phosphor, glyph, tint, 14.0);
     let text_col = commands.spawn(Node { flex_direction: FlexDirection::Column, row_gap: Val::Px(2.0), flex_grow: 1.0, min_width: Val::Px(0.0), overflow: Overflow::clip(), ..default() }).id();
     let msg_lbl = commands.spawn((Text::new(msg.to_string()), ui_font(&fonts.mono, 11.5), TextColor(rgb(text_primary())), bevy::text::TextLayout::no_wrap())).id();
     let location = match (line, col) {
@@ -112,8 +164,11 @@ fn problem_row(commands: &mut Commands, fonts: &EmberFonts, file_idx: usize, nam
 fn problems_goto_click(q: Query<(&Interaction, &ProblemRow), Changed<Interaction>>, state: Option<ResMut<CodeEditorState>>) {
     let Some(mut state) = state else { return };
     for (interaction, row) in &q {
-        if *interaction == Interaction::Pressed {
-            state.active_tab = Some(row.file_idx);
+        if *interaction != Interaction::Pressed {
+            continue;
+        }
+        if let Some(idx) = row.file_idx {
+            state.active_tab = Some(idx);
             state.pending_goto_line = Some(row.line);
         }
     }

--- a/crates/renzora_ember/src/widgets/code_editor/systems.rs
+++ b/crates/renzora_ember/src/widgets/code_editor/systems.rs
@@ -828,6 +828,49 @@ pub(crate) fn code_theme_watch(
     }
 }
 
+pub(crate) fn code_caret(time: Res<Time>, editors: Query<&CodeEditor>, mut nodes: Query<&mut Node>) {
+    let on = (time.elapsed_secs() * 1.6).fract() < 0.5;
+    for ed in &editors {
+        let Ok(mut n) = nodes.get_mut(ed.caret) else {
+            continue;
+        };
+        let m = ed.metrics();
+        let rows = ed.rows();
+        let cr = layout::row_of(&rows, ed.cursor_line, ed.cursor_col);
+        let on_screen = cr >= ed.scroll && cr < ed.scroll + ed.visible;
+        // Assign through `set_if_neq`-style guards: this runs every frame, and a
+        // plain write marks the node changed, which makes bevy_ui re-run layout
+        // on it (and its ancestors) 60 times a second for a caret that hasn't
+        // moved. Only the blink phase should normally cost anything.
+        let want = if ed.focused && on && on_screen && m.char_w > 0.0 {
+            let x_col = ed.cursor_col.saturating_sub(rows[cr].start_col);
+            Some((
+                Val::Px(m.caret_h),
+                Val::Px(m.gutter_w + m.pad + x_col as f32 * m.char_w),
+                Val::Px((cr - ed.scroll) as f32 * m.line_h + (m.line_h - m.caret_h) / 2.0),
+            ))
+        } else {
+            None
+        };
+        match want {
+            Some((height, left, top)) => {
+                if n.display != Display::Flex || n.height != height || n.left != left || n.top != top {
+                    let n = &mut *n;
+                    n.display = Display::Flex;
+                    n.height = height;
+                    n.left = left;
+                    n.top = top;
+                }
+            }
+            None => {
+                if n.display != Display::None {
+                    n.display = Display::None;
+                }
+            }
+        }
+    }
+}
+
 /// Drive the editor's real systems headlessly so a key storm can be replayed in
 /// a test. The widget spawns plain components (no layout/render needed), so an
 /// `App` with `MinimalPlugins` + `InputPlugin` exercises input → edit → render
@@ -1052,48 +1095,5 @@ mod tests {
             edit::toggle_fold(&mut ed, 1);
         }
         hold(&mut app, editor, Key::Delete, KeyCode::Delete, 2);
-    }
-}
-
-pub(crate) fn code_caret(time: Res<Time>, editors: Query<&CodeEditor>, mut nodes: Query<&mut Node>) {
-    let on = (time.elapsed_secs() * 1.6).fract() < 0.5;
-    for ed in &editors {
-        let Ok(mut n) = nodes.get_mut(ed.caret) else {
-            continue;
-        };
-        let m = ed.metrics();
-        let rows = ed.rows();
-        let cr = layout::row_of(&rows, ed.cursor_line, ed.cursor_col);
-        let on_screen = cr >= ed.scroll && cr < ed.scroll + ed.visible;
-        // Assign through `set_if_neq`-style guards: this runs every frame, and a
-        // plain write marks the node changed, which makes bevy_ui re-run layout
-        // on it (and its ancestors) 60 times a second for a caret that hasn't
-        // moved. Only the blink phase should normally cost anything.
-        let want = if ed.focused && on && on_screen && m.char_w > 0.0 {
-            let x_col = ed.cursor_col.saturating_sub(rows[cr].start_col);
-            Some((
-                Val::Px(m.caret_h),
-                Val::Px(m.gutter_w + m.pad + x_col as f32 * m.char_w),
-                Val::Px((cr - ed.scroll) as f32 * m.line_h + (m.line_h - m.caret_h) / 2.0),
-            ))
-        } else {
-            None
-        };
-        match want {
-            Some((height, left, top)) => {
-                if n.display != Display::Flex || n.height != height || n.left != left || n.top != top {
-                    let n = &mut *n;
-                    n.display = Display::Flex;
-                    n.height = height;
-                    n.left = left;
-                    n.top = top;
-                }
-            }
-            None => {
-                if n.display != Display::None {
-                    n.display = Display::None;
-                }
-            }
-        }
     }
 }

--- a/crates/renzora_ember/src/widgets/node_graph/cable.wgsl
+++ b/crates/renzora_ember/src/widgets/node_graph/cable.wgsl
@@ -58,8 +58,8 @@ fn fragment(in: UiVertexOutput) -> @location(0) vec4<f32> {
         let sd = seg_dist(p, prev, cur);
         if sd < d {
             d = sd;
-            // Interpolate within the segment: the closest point sits partway
-            // between prev_t and t in proportion to how the distances fall off.
+            // Refine within the segment: take the closest point as its
+            // midpoint. At this polyline density the error is sub-pixel.
             best_t = (prev_t + t) * 0.5;
         }
         prev = cur;

--- a/crates/renzora_ember/src/widgets/node_graph/cable.wgsl
+++ b/crates/renzora_ember/src/widgets/node_graph/cable.wgsl
@@ -10,6 +10,8 @@ struct CableUniforms {
     // p2.xy, p3.xy
     cd: vec4<f32>,
     color: vec4<f32>,
+    // Colour at the cable's far end; equal to `color` for same-type wires.
+    color_b: vec4<f32>,
     // x = stroke width (px), y = feather (px)
     params: vec4<f32>,
 };
@@ -43,14 +45,25 @@ fn fragment(in: UiVertexOutput) -> @location(0) vec4<f32> {
     let feather = max(u.params.y, 0.001);
 
     // Distance to the curve, approximated by a dense polyline of the cubic.
+    // `best_t` tracks the curve parameter at the closest point so the stroke
+    // can run a gradient from the source pin's colour to the target's.
     var prev = p0;
+    var prev_t = 0.0;
     var d = 1.0e9;
+    var best_t = 0.0;
     let n = 30;
     for (var i = 1; i <= n; i = i + 1) {
         let t = f32(i) / f32(n);
         let cur = cubic(p0, p1, p2, p3, t);
-        d = min(d, seg_dist(p, prev, cur));
+        let sd = seg_dist(p, prev, cur);
+        if sd < d {
+            d = sd;
+            // Interpolate within the segment: the closest point sits partway
+            // between prev_t and t in proportion to how the distances fall off.
+            best_t = (prev_t + t) * 0.5;
+        }
         prev = cur;
+        prev_t = t;
     }
 
     let edge = d - width * 0.5;
@@ -59,5 +72,6 @@ fn fragment(in: UiVertexOutput) -> @location(0) vec4<f32> {
     if alpha <= 0.0 {
         discard;
     }
-    return vec4<f32>(u.color.rgb, u.color.a * alpha);
+    let rgb = mix(u.color.rgb, u.color_b.rgb, best_t);
+    return vec4<f32>(rgb, u.color.a * alpha);
 }

--- a/crates/renzora_ember/src/widgets/node_graph/mod.rs
+++ b/crates/renzora_ember/src/widgets/node_graph/mod.rs
@@ -107,7 +107,7 @@ pub(crate) fn apply_node_graph_style(
     }
 }
 
-/// GPU-painted bezier cable: control points + color + stroke params.
+/// GPU-painted bezier cable: control points + endpoint colors + stroke params.
 #[derive(Asset, TypePath, AsBindGroup, Clone)]
 pub(crate) struct CableMaterial {
     #[uniform(0)]
@@ -116,6 +116,11 @@ pub(crate) struct CableMaterial {
     cd: Vec4,
     #[uniform(0)]
     color: Vec4,
+    /// Colour at the cable's far end. Differs from `color` when the two pins
+    /// have different types (a Vec2 feeding a Color input): the cable runs a
+    /// gradient source→target so a type coercion is visible on the wire.
+    #[uniform(0)]
+    color_b: Vec4,
     #[uniform(0)]
     params: Vec4,
 }
@@ -123,10 +128,12 @@ pub(crate) struct CableMaterial {
 impl Default for CableMaterial {
     fn default() -> Self {
         let c = rgb(accent()).to_linear();
+        let v = Vec4::new(c.red, c.green, c.blue, 1.0);
         Self {
             ab: Vec4::ZERO,
             cd: Vec4::ZERO,
-            color: Vec4::new(c.red, c.green, c.blue, 1.0),
+            color: v,
+            color_b: v,
             params: Vec4::new(WIRE_W, 1.0, 0.0, 0.0),
         }
     }
@@ -742,6 +749,7 @@ pub(crate) fn update_endpoints(
             m.ab = Vec4::new(p0.x, p0.y, p1.x, p1.y);
             m.cd = Vec4::new(p2.x, p2.y, p3.x, p3.y);
             m.color = Vec4::new(accent.red, accent.green, accent.blue, 1.0);
+            m.color_b = m.color;
             // Stroke width / feather in physical px (constant logical thickness).
             m.params = Vec4::new(WIRE_W / isf, 1.0, 0.0, 0.0);
         }

--- a/crates/renzora_ember/src/widgets/node_graph/view.rs
+++ b/crates/renzora_ember/src/widgets/node_graph/view.rs
@@ -86,9 +86,10 @@ pub struct NodeGraphView {
     /// The (multi-) selection set — drives node borders in place (no rebuild, so
     /// a drag-started selection never kills the drag).
     pub selected: HashSet<u64>,
-    /// The port a cable is being dragged from: `(node, pin, is_output, colour)`.
-    /// Releasing over an opposite-direction, colour-matching port completes it.
-    pub pending_connect: Option<(u64, String, bool, (u8, u8, u8))>,
+    /// The port a cable is being dragged from: `(node, pin, is_output, colour,
+    /// compat_group)`. Releasing over an opposite-direction port in the same
+    /// group completes it. Colour rides along only to tint the preview cable.
+    pub pending_connect: Option<(u64, String, bool, (u8, u8, u8), u32)>,
     /// Caller sets to re-frame all nodes; cleared by the widget once applied.
     pub fit_request: bool,
     /// Whether this view has ever been framed. A graph's node positions belong to
@@ -160,6 +161,11 @@ struct NgvPort {
     pin: String,
     is_output: bool,
     color: (u8, u8, u8),
+    /// Compatibility group: a cable can drop on a port of the opposite
+    /// direction in the **same group**. Callers group their pin types so
+    /// colour can stay per-type (a Vec2 and a Color pin look different) while
+    /// every mutually-coercible type shares a group and interconnects.
+    group: u32,
     viewport: Entity,
     /// The port's label, whose background is tinted while the grab slot is hovered
     /// (sized to the text, so the highlight tracks the name, not the whole row).
@@ -275,8 +281,12 @@ pub fn node_graph_view(commands: &mut Commands, _fonts: &EmberFonts) -> NodeGrap
     NodeGraphHandle { viewport, canvas }
 }
 
-/// Build one node at `(x, y)` (canvas px) with typed input/output pins
-/// (`(pin_id, label)`). Returns the node entity (add it to `handle.canvas`).
+/// Build one node at `(x, y)` (canvas px) with typed input/output pins.
+/// Pins are `(pin_id, label, colour, compat_group)`: colour is purely visual,
+/// while a dragged cable can only drop on an opposite-direction pin in the
+/// same group — so coercible types (a Vec2 and a Color) share a group even
+/// though their dot colours differ. Returns the node entity (add it to
+/// `handle.canvas`).
 #[allow(clippy::too_many_arguments)]
 pub fn graph_node_view(
     commands: &mut Commands,
@@ -286,8 +296,8 @@ pub fn graph_node_view(
     node_id: u64,
     title: &str,
     color: (u8, u8, u8),
-    inputs: &[(String, String, (u8, u8, u8))],
-    outputs: &[(String, String, (u8, u8, u8))],
+    inputs: &[(String, String, (u8, u8, u8), u32)],
+    outputs: &[(String, String, (u8, u8, u8), u32)],
     x: f32,
     y: f32,
     selected: bool,
@@ -361,8 +371,8 @@ pub fn graph_node_view(
     }
     commands.entity(node).add_child(title_bar);
 
-    for (idx, (pin, label, pin_color)) in inputs.iter().enumerate() {
-        let r = port_row(commands, fonts, node_id, viewport, pin, label, false, *pin_color);
+    for (idx, (pin, label, pin_color, group)) in inputs.iter().enumerate() {
+        let r = port_row(commands, fonts, node_id, viewport, pin, label, false, *pin_color, *group);
         commands.entity(node).add_child(r);
         // Inline value editor for an unconnected input, on its own row. Left-aligned
         // to sit under the pin it belongs to — input pins hug the left edge, so a
@@ -412,8 +422,8 @@ pub fn graph_node_view(
     } else {
         node
     };
-    for (pin, label, pin_color) in outputs {
-        let r = port_row(commands, fonts, node_id, viewport, pin, label, true, *pin_color);
+    for (pin, label, pin_color, group) in outputs {
+        let r = port_row(commands, fonts, node_id, viewport, pin, label, true, *pin_color, *group);
         commands.entity(out_col).add_child(r);
     }
     // Optional preview thumbnail (e.g. texture nodes). Output pins hug the right
@@ -467,7 +477,7 @@ pub fn graph_node_view(
 /// lands the cable endpoint at the node edge. Hovering the slot tints the row (see
 /// [`ngv_highlight_slots`]) to advertise the grab.
 #[allow(clippy::too_many_arguments)]
-fn port_row(commands: &mut Commands, fonts: &EmberFonts, node_id: u64, viewport: Entity, pin: &str, label: &str, is_output: bool, color: (u8, u8, u8)) -> Entity {
+fn port_row(commands: &mut Commands, fonts: &EmberFonts, node_id: u64, viewport: Entity, pin: &str, label: &str, is_output: bool, color: (u8, u8, u8), group: u32) -> Entity {
     let row = commands
         .spawn((
             Node {
@@ -514,7 +524,7 @@ fn port_row(commands: &mut Commands, fonts: &EmberFonts, node_id: u64, viewport:
                 width: Val::Px(SLOT_W),
                 ..default()
             },
-            NgvPort { node_id, pin: pin.to_string(), is_output, color, viewport, label: text },
+            NgvPort { node_id, pin: pin.to_string(), is_output, color, group, viewport, label: text },
             Interaction::default(),
             crate::cursor_icon::HoverCursor(SystemCursorIcon::Crosshair),
             Name::new("ngv-port-slot"),
@@ -738,7 +748,7 @@ fn ngv_preview(
         // Live drag follows the cursor; otherwise a parked (frozen) cable runs to
         // the open menu's anchor.
         let endpoint = graphs.get(pv.viewport).ok().and_then(|g| {
-            if let Some((nid, pin, is_out, _)) = g.pending_connect.clone() {
+            if let Some((nid, pin, is_out, _, _)) = g.pending_connect.clone() {
                 cur.map(|c| (nid, pin, is_out, c))
             } else {
                 g.frozen_cable
@@ -766,6 +776,8 @@ fn ngv_preview(
             m.ab = Vec4::new(a.x, a.y, c1.x, c1.y);
             m.cd = Vec4::new(c2.x, c2.y, b.x, b.y);
             m.color = Vec4::new(lin.red, lin.green, lin.blue, 0.7);
+            // A dragged cable has no target yet — single hue until it lands.
+            m.color_b = m.color;
             m.params = Vec4::new(WIRE_W / isf, 1.0, 0.0, 0.0);
         }
         node.display = Display::Flex;
@@ -913,7 +925,7 @@ fn ngv_connect(
         }
         if let Some((_, p)) = ports.iter().find(|(i, _)| **i == Interaction::Pressed) {
             if let Ok((_, mut g, _, _, _)) = graphs.get_mut(p.viewport) {
-                g.pending_connect = Some((p.node_id, p.pin.clone(), p.is_output, p.color));
+                g.pending_connect = Some((p.node_id, p.pin.clone(), p.is_output, p.color, p.group));
             }
         }
     }
@@ -921,13 +933,13 @@ fn ngv_connect(
         let target = ports
             .iter()
             .find(|(i, _)| matches!(i, Interaction::Hovered | Interaction::Pressed))
-            .map(|(_, p)| (p.viewport, p.node_id, p.pin.clone(), p.is_output, p.color));
+            .map(|(_, p)| (p.viewport, p.node_id, p.pin.clone(), p.is_output, p.color, p.group));
         let cur = cursor(&windows);
         for (vp, mut g, rcp, vcn, children) in &mut graphs {
-            let Some((snode, spin, s_out, scol)) = g.pending_connect.take() else { continue };
+            let Some((snode, spin, s_out, scol, sgroup)) = g.pending_connect.take() else { continue };
             // 1) Released over a compatible port → make the connection.
-            if let Some((tvp, tnode, tpin, t_out, tcol)) = &target {
-                if *tvp == vp && *t_out != s_out && *tcol == scol && *tnode != snode {
+            if let Some((tvp, tnode, tpin, t_out, _, tgroup)) = &target {
+                if *tvp == vp && *t_out != s_out && *tgroup == sgroup && *tnode != snode {
                     let (from_node, from_pin, to_node, to_pin) = if s_out {
                         (snode, spin, *tnode, tpin.clone())
                     } else {
@@ -964,9 +976,9 @@ fn ngv_highlight_slots(graphs: Query<&NodeGraphView>, ports: Query<(&NgvPort, &I
         let hovered = matches!(interaction, Interaction::Hovered | Interaction::Pressed);
         // A port is connectable in the current context: always when no cable is
         // being dragged, else only if it's a compatible drop target (opposite
-        // direction, matching colour, a different node).
+        // direction, same compat group, a different node).
         let connectable = match &pending {
-            Some((snode, _, s_out, scol)) => port.is_output != *s_out && port.color == *scol && port.node_id != *snode,
+            Some((snode, _, s_out, _, sgroup)) => port.is_output != *s_out && port.group == *sgroup && port.node_id != *snode,
             None => true,
         };
         // Tint the label background (sized to the text) only when hovering a port
@@ -979,9 +991,9 @@ fn ngv_highlight_slots(graphs: Query<&NodeGraphView>, ports: Query<(&NgvPort, &I
             }
         }
         let (visible, size) = match &pending {
-            Some((snode, spin, s_out, scol)) => {
+            Some((snode, spin, s_out, _, sgroup)) => {
                 let is_source = port.node_id == *snode && &port.pin == spin && port.is_output == *s_out;
-                let valid = port.is_output != *s_out && port.color == *scol && port.node_id != *snode;
+                let valid = port.is_output != *s_out && port.group == *sgroup && port.node_id != *snode;
                 if is_source {
                     (true, 13.0)
                 } else if valid {
@@ -1280,7 +1292,7 @@ fn ngv_endpoints(mut materials: ResMut<Assets<CableMaterial>>, wires: Query<(&Ng
     }
     let map = port_map(&ports);
     for (w, mat) in &wires {
-        let (Some(&(p0, wire_col)), Some(&(p3, _))) = (map.get(&(w.from_node, w.from_pin.clone(), true)), map.get(&(w.to_node, w.to_pin.clone(), false))) else {
+        let (Some(&(p0, wire_col)), Some(&(p3, target_col))) = (map.get(&(w.from_node, w.from_pin.clone(), true)), map.get(&(w.to_node, w.to_pin.clone(), false))) else {
             continue;
         };
         let (Ok(vgt), Ok(vcn)) = (transforms.get(w.viewport), computeds.get(w.viewport)) else {
@@ -1291,11 +1303,13 @@ fn ngv_endpoints(mut materials: ResMut<Assets<CableMaterial>>, wires: Query<(&Ng
         let a = p0 - top_left;
         let b = p3 - top_left;
         let (c1, c2) = control_points(a, b);
-        let lin = rgb(wire_col).to_linear(); // wire takes the output pin's colour
+        let lin = rgb(wire_col).to_linear(); // wire starts at the output pin's colour…
+        let lin_b = rgb(target_col).to_linear(); // …and fades to the input pin's
         if let Some(mut m) = materials.get_mut(&mat.0) {
             m.ab = Vec4::new(a.x, a.y, c1.x, c1.y);
             m.cd = Vec4::new(c2.x, c2.y, b.x, b.y);
             m.color = Vec4::new(lin.red, lin.green, lin.blue, 1.0);
+            m.color_b = Vec4::new(lin_b.red, lin_b.green, lin_b.blue, 1.0);
             m.params = Vec4::new(WIRE_W / isf, 1.0, 0.0, 0.0);
         }
     }

--- a/crates/renzora_ember/src/widgets/tooltip.rs
+++ b/crates/renzora_ember/src/widgets/tooltip.rs
@@ -24,6 +24,11 @@ impl HoverTooltip {
     }
 }
 
+/// Place the bubble above the hovered entity's own rect instead of beside the
+/// cursor — for things the user points at rather than reads (graph nodes).
+#[derive(Component)]
+pub struct TooltipAnchorAbove;
+
 /// Legacy wrapper API: wraps `target` in a hoverable node carrying a
 /// [`HoverTooltip`]. Prefer inserting `HoverTooltip` directly on widgets that
 /// already track `Interaction`.
@@ -58,6 +63,9 @@ pub(crate) struct HoverTipText;
 const SHOW_DELAY: f32 = 0.35;
 /// Cursor → bubble offset (logical px).
 const OFFSET: Vec2 = Vec2::new(14.0, 20.0);
+/// The bubble's maximum width — long diagnostics wrap instead of running off
+/// the window.
+const MAX_WIDTH: f32 = 360.0;
 
 pub(crate) fn hover_tooltip_system(
     mut commands: Commands,
@@ -65,7 +73,14 @@ pub(crate) fn hover_tooltip_system(
     windows: Query<(Entity, &Window)>,
     dock_windows: Option<Res<crate::dock::DockWindows>>,
     fonts: Option<Res<EmberFonts>>,
-    tips: Query<(Entity, &Interaction, &HoverTooltip)>,
+    tips: Query<(
+        Entity,
+        &Interaction,
+        &HoverTooltip,
+        Option<&ComputedNode>,
+        Option<&GlobalTransform>,
+        Has<TooltipAnchorAbove>,
+    )>,
     mut root_q: Query<(Entity, &mut Node, &ComputedNode), With<HoverTipRoot>>,
     mut text_q: Query<&mut Text, With<HoverTipText>>,
     mut state: Local<Option<(Entity, f32)>>,
@@ -81,14 +96,14 @@ pub(crate) fn hover_tooltip_system(
 
     let hovered = tips
         .iter()
-        .find(|(_, i, _)| matches!(i, Interaction::Hovered | Interaction::Pressed));
+        .find(|(_, i, _, _, _, _)| matches!(i, Interaction::Hovered | Interaction::Pressed));
     // The window the cursor is in — hover only fires there, so the tooltip's
     // coordinates and rendering target both follow it (a widget in a floating
     // dock window shows its tooltip in that window, not the primary).
     let cursor_win = windows
         .iter()
         .find_map(|(e, w)| w.cursor_position().map(|c| (e, w, c)));
-    let (Some((widget, _, tip)), Some((win_entity, win, cursor))) = (hovered, cursor_win) else {
+    let (Some((widget, _, tip, widget_cn, widget_tf, anchor_above)), Some((win_entity, win, cursor))) = (hovered, cursor_win) else {
         *state = None;
         hide(&mut root_q);
         return;
@@ -118,6 +133,7 @@ pub(crate) fn hover_tooltip_system(
                     position_type: PositionType::Absolute,
                     left: Val::Px(cursor.x + OFFSET.x),
                     top: Val::Px(cursor.y + OFFSET.y),
+                    max_width: Val::Px(MAX_WIDTH),
                     padding: UiRect::axes(Val::Px(8.0), Val::Px(4.0)),
                     border: UiRect::all(Val::Px(1.0)),
                     border_radius: BorderRadius::all(Val::Px(4.0)),
@@ -139,7 +155,7 @@ pub(crate) fn hover_tooltip_system(
                 Text::new(tip.0.clone()),
                 ui_font(&fonts.ui, 11.0),
                 TextColor(rgb(text_primary())),
-                bevy::text::TextLayout::no_wrap(),
+                bevy::text::TextLayout::linebreak(bevy::text::LineBreak::WordBoundary),
                 Pickable::IGNORE,
                 HoverTipText,
             ))
@@ -173,15 +189,38 @@ pub(crate) fn hover_tooltip_system(
         }
     }
 
-    // Place beside the cursor, flipping/clamping at the window edges.
+    // Place the bubble. `TooltipAnchorAbove` centers it over the hovered
+    // entity's own rect (flipping below when there is no room); everything
+    // else rides beside the cursor, flipping/clamping at the window edges.
     // ComputedNode is physical px; Node offsets are logical.
     let size = cn.size() * cn.inverse_scale_factor();
-    let mut pos = cursor + OFFSET;
+    let anchored = anchor_above
+        .then(|| widget_cn.zip(widget_tf))
+        .flatten()
+        .map(|(wcn, wtf)| {
+            let half = wcn.size() * wcn.inverse_scale_factor() * 0.5;
+            let center = wtf.translation().xy() * wcn.inverse_scale_factor();
+            // Above the widget; below it when the bubble would leave the window.
+            let mut y = center.y - half.y - size.y - 8.0;
+            if y < 0.0 {
+                y = center.y + half.y + 8.0;
+            }
+            Vec2::new(center.x - size.x * 0.5, y)
+        });
+    let mut pos = anchored.unwrap_or(cursor + OFFSET);
     if pos.x + size.x > win.width() {
-        pos.x = (cursor.x - size.x - 8.0).max(0.0);
+        pos.x = if anchored.is_some() {
+            (win.width() - size.x).max(0.0)
+        } else {
+            (cursor.x - size.x - 8.0).max(0.0)
+        };
     }
     if pos.y + size.y > win.height() {
-        pos.y = (cursor.y - size.y - 8.0).max(0.0);
+        pos.y = if anchored.is_some() {
+            (win.height() - size.y).max(0.0)
+        } else {
+            (cursor.y - size.y - 8.0).max(0.0)
+        };
     }
     node.left = Val::Px(pos.x);
     node.top = Val::Px(pos.y);

--- a/crates/renzora_material_editor/Cargo.toml
+++ b/crates/renzora_material_editor/Cargo.toml
@@ -9,7 +9,9 @@ bevy = { workspace = true }
 renzora = { path = "../renzora", default-features = false, features = ["editor"] }
 renzora_splash = { path = "../renzora_splash" }
 renzora_ember = { path = "../renzora_ember" }
-renzora_shader = { path = "../renzora_shader" }
+# `editor`: the Problems-panel shader validator lives behind that feature; the
+# panel this crate hosts is what it feeds.
+renzora_shader = { path = "../renzora_shader", features = ["editor"] }
 renzora_undo = { path = "../renzora_undo" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/renzora_material_editor/src/lib.rs
+++ b/crates/renzora_material_editor/src/lib.rs
@@ -232,6 +232,7 @@ pub(crate) fn note_save_warnings(world: &mut World, path: &str, warnings: &[Stri
                 severity: ProblemSeverity::Warning,
                 message: w.clone(),
                 line: None,
+                node_id: None,
             })
             .collect(),
     );

--- a/crates/renzora_material_editor/src/lib.rs
+++ b/crates/renzora_material_editor/src/lib.rs
@@ -219,6 +219,7 @@ pub fn save_material_graph(world: &mut World, path: &str, graph: &mut MaterialGr
 pub(crate) fn note_save_warnings(world: &mut World, path: &str, warnings: &[String]) {
     for warning in warnings {
         warn!("[material_editor] codegen warning in '{}': {}", path, warning);
+        renzora::console_log::console_warn("Material", format!("{path}: {warning}"));
     }
     let Some(mut problems) = world.get_resource_mut::<ContentProblems>() else {
         return;

--- a/crates/renzora_material_editor/src/lib.rs
+++ b/crates/renzora_material_editor/src/lib.rs
@@ -13,6 +13,7 @@ mod pin_editors;
 pub mod preview;
 
 use bevy::prelude::*;
+use renzora::content_problems::{ContentProblem, ContentProblems, ProblemSeverity};
 use renzora::core::CurrentProject;
 use renzora_editor_framework::{material_thumb_path, AppEditorExt, MaterialThumbnailRegistry};
 use renzora_shader::material::graph::{MaterialDomain, MaterialGraph};
@@ -164,7 +165,7 @@ pub fn save_material_graph(world: &mut World, path: &str, graph: &mut MaterialGr
         let _ = std::fs::create_dir_all(parent);
     }
 
-    let (graph_json, errors) =
+    let (graph_json, report) =
         match renzora_shader::material::precompiled::save_compiled_and_serialize(graph, &fs_path) {
             Ok(out) => out,
             Err(e) => {
@@ -172,9 +173,10 @@ pub fn save_material_graph(world: &mut World, path: &str, graph: &mut MaterialGr
                 return false;
             }
         };
-    for err in &errors {
+    for err in &report.errors {
         warn!("[material_editor] codegen error in '{}': {}", path, err);
     }
+    note_save_warnings(world, path, &report.warnings);
 
     if let Err(e) = std::fs::write(&fs_path, &graph_json) {
         warn!("[material_editor] Save failed: {}", e);
@@ -207,6 +209,32 @@ pub fn save_material_graph(world: &mut World, path: &str, graph: &mut MaterialGr
         world.entity_mut(entity).remove::<MaterialResolved>();
     }
     true
+}
+
+/// Console + Problems panel for a save-compile's warnings.
+///
+/// Compile sites own the path's Warning rows — `set_severity` replaces them
+/// without touching whatever the validator has to say. An empty `warnings`
+/// still runs: a repaired graph must clear last save's rows.
+pub(crate) fn note_save_warnings(world: &mut World, path: &str, warnings: &[String]) {
+    for warning in warnings {
+        warn!("[material_editor] codegen warning in '{}': {}", path, warning);
+    }
+    let Some(mut problems) = world.get_resource_mut::<ContentProblems>() else {
+        return;
+    };
+    problems.set_severity(
+        path,
+        ProblemSeverity::Warning,
+        warnings
+            .iter()
+            .map(|w| ContentProblem {
+                severity: ProblemSeverity::Warning,
+                message: w.clone(),
+                line: None,
+            })
+            .collect(),
+    );
 }
 
 /// Load the graph at `path`, hand it to `edit`, and save it if `edit` changed

--- a/crates/renzora_material_editor/src/native_graph.rs
+++ b/crates/renzora_material_editor/src/native_graph.rs
@@ -380,6 +380,10 @@ struct NodeSnap {
     /// One entry per input pin, index-aligned with `inputs`: the pin template and
     /// whether it should carry an inline value editor. See [`wants_editor`].
     in_specs: Vec<(PinTemplate, bool)>,
+    /// The shader compiler's complaint about this node, if any — joined from
+    /// `ContentProblems` for the active material. Drives the header's warning
+    /// icon and the node's tooltip.
+    error: Option<String>,
 }
 
 /// Should this input pin show an inline value editor on the node?
@@ -412,6 +416,11 @@ fn wants_editor(graph: &MaterialGraph, node: &renzora_shader::material::graph::M
 fn node_snapshot(world: &Rx, canvas: Entity, viewport: Entity) -> KeyedSnapshot {
     let Some(s) = world.get_resource::<MaterialEditorState>() else { return empty() };
     let assets = world.get_resource::<AssetServer>();
+    let problems = world.get_resource::<renzora::content_problems::ContentProblems>();
+    let active_path = s
+        .active_tab
+        .and_then(|i| s.tabs.get(i))
+        .and_then(|t| t.path.as_deref());
     let sel = s.selected_node;
     let nodes: Vec<NodeSnap> = s
         .graph
@@ -435,7 +444,16 @@ fn node_snapshot(world: &Rx, canvas: Entity, viewport: Entity) -> KeyedSnapshot 
                 .filter(|p| p.direction == PinDir::Input)
                 .map(|p| ((*p).clone(), wants_editor(&s.graph, n, p)))
                 .collect();
-            NodeSnap { id: n.id, title, color, pos: n.position, inputs, outputs, selected: sel == Some(n.id), tex_path, thumb, sample_idx, in_specs }
+            let error = active_path.zip(problems).and_then(|(path, problems)| {
+                let messages: Vec<&str> = problems
+                    .get(path)
+                    .iter()
+                    .filter(|p| p.node_id == Some(n.id))
+                    .map(|p| p.message.as_str())
+                    .collect();
+                (!messages.is_empty()).then(|| messages.join("\n"))
+            });
+            NodeSnap { id: n.id, title, color, pos: n.position, inputs, outputs, selected: sel == Some(n.id), tex_path, thumb, sample_idx, in_specs, error }
         })
         .collect();
     let items: Vec<(u64, u64)> = nodes
@@ -450,9 +468,10 @@ fn node_snapshot(world: &Rx, canvas: Entity, viewport: Entity) -> KeyedSnapshot 
             // two-way. `sample_idx` is included so switching a sample node's type
             // rebuilds it (new pins + the dropdown's new selection), and the
             // per-input editor flags so wiring a pin makes its inline editor
-            // disappear (and unwiring brings it back).
+            // disappear (and unwiring brings it back), and the compile error so
+            // the warning icon appears when it lands and clears when it heals.
             let editors: Vec<bool> = n.in_specs.iter().map(|(_, e)| *e).collect();
-            (&n.title, n.color, &n.inputs, &n.outputs, &n.tex_path, n.sample_idx, &editors).hash(&mut h);
+            (&n.title, n.color, &n.inputs, &n.outputs, &n.tex_path, n.sample_idx, &editors, &n.error).hash(&mut h);
             (k.finish(), h.finish())
         })
         .collect();
@@ -460,7 +479,10 @@ fn node_snapshot(world: &Rx, canvas: Entity, viewport: Entity) -> KeyedSnapshot 
         items,
         build: Box::new(move |c, f, i| {
             let n = &nodes[i];
-            let header = n.sample_idx.map(|_| sample_switch_button(c, f, n.id));
+            let header = match (n.error.is_some(), n.sample_idx) {
+                (false, None) => None,
+                (has_error, sample) => Some(node_header_controls(c, f, n.id, has_error, sample)),
+            };
             // Values are edited on the node itself — this is the only place they
             // live now, so `wants_editor` above decides which pins get one.
             let editors: Vec<Option<Entity>> = n
@@ -468,9 +490,41 @@ fn node_snapshot(world: &Rx, canvas: Entity, viewport: Entity) -> KeyedSnapshot 
                 .iter()
                 .map(|(pin, wanted)| wanted.then(|| crate::pin_editors::pin_editor(c, f, n.id, pin)))
                 .collect();
-            graph_node_view(c, f, canvas, viewport, n.id, &n.title, n.color, &n.inputs, &n.outputs, n.pos[0], n.pos[1], n.selected, n.thumb.clone(), &editors, header)
+            let node = graph_node_view(c, f, canvas, viewport, n.id, &n.title, n.color, &n.inputs, &n.outputs, n.pos[0], n.pos[1], n.selected, n.thumb.clone(), &editors, header);
+            if let Some(error) = &n.error {
+                c.entity(node).insert((
+                    renzora_ember::widgets::HoverTooltip::new(error.clone()),
+                    renzora_ember::widgets::TooltipAnchorAbove,
+                ));
+            }
+            node
         }),
     }
+}
+
+/// The title bar's trailing controls: a red warning icon when the shader
+/// compiler has something to say about the node, plus the sample-variant
+/// caret when the node has one. One row entity, because the widget's header
+/// slot takes a single child.
+fn node_header_controls(commands: &mut Commands, fonts: &EmberFonts, node_id: u64, has_error: bool, sample_idx: Option<usize>) -> Entity {
+    let row = commands
+        .spawn(Node {
+            flex_direction: FlexDirection::Row,
+            align_items: AlignItems::Center,
+            column_gap: Val::Px(4.0),
+            flex_shrink: 0.0,
+            ..default()
+        })
+        .id();
+    if has_error {
+        let icon = icon_text(commands, &fonts.phosphor, "warning", close_red(), 13.0);
+        commands.entity(row).add_child(icon);
+    }
+    if sample_idx.is_some() {
+        let caret = sample_switch_button(commands, fonts, node_id);
+        commands.entity(row).add_child(caret);
+    }
+    row
 }
 
 /// A small caret button for a texture-sample node's header. The node title already

--- a/crates/renzora_material_editor/src/native_graph.rs
+++ b/crates/renzora_material_editor/src/native_graph.rs
@@ -348,7 +348,21 @@ fn pin_rgb(t: PinType) -> (u8, u8, u8) {
     }
 }
 
-type Port = (String, String, (u8, u8, u8));
+/// The graph widget's drop-filter group — mirrors `PinType::compatible`:
+/// the whole numeric family interconnects (vec sizes coerce at codegen),
+/// every other type only connects to itself. Pin *colour* stays per-type, so
+/// a Vec2 → Color wire is allowed and shows the gradient between the two.
+fn pin_group(t: PinType) -> u32 {
+    match t {
+        PinType::Float | PinType::Vec2 | PinType::Vec3 | PinType::Vec4 | PinType::Color => 0,
+        PinType::Bool => 1,
+        PinType::Texture2D => 2,
+        PinType::Sampler => 3,
+        PinType::String => 4,
+    }
+}
+
+type Port = (String, String, (u8, u8, u8), u32);
 
 struct NodeSnap {
     id: u64,
@@ -408,8 +422,8 @@ fn node_snapshot(world: &Rx, canvas: Entity, viewport: Entity) -> KeyedSnapshot 
             let title = def.map(|d| d.display_name.to_string()).unwrap_or_else(|| n.node_type.clone());
             let color = def.map(|d| (d.color[0], d.color[1], d.color[2])).unwrap_or((90, 90, 100));
             let pins = def.map(|d| (d.pins)()).unwrap_or_default();
-            let inputs: Vec<Port> = pins.iter().filter(|p| p.direction == PinDir::Input).map(|p| (p.name.clone(), p.label.clone(), pin_rgb(p.pin_type))).collect();
-            let outputs: Vec<Port> = pins.iter().filter(|p| p.direction == PinDir::Output).map(|p| (p.name.clone(), p.label.clone(), pin_rgb(p.pin_type))).collect();
+            let inputs: Vec<Port> = pins.iter().filter(|p| p.direction == PinDir::Input).map(|p| (p.name.clone(), p.label.clone(), pin_rgb(p.pin_type), pin_group(p.pin_type))).collect();
+            let outputs: Vec<Port> = pins.iter().filter(|p| p.direction == PinDir::Output).map(|p| (p.name.clone(), p.label.clone(), pin_rgb(p.pin_type), pin_group(p.pin_type))).collect();
             let tex_path = n.input_values.get("texture").and_then(|v| match v {
                 PinValue::TexturePath(p) if !p.is_empty() => Some(p.clone()),
                 _ => None,
@@ -804,8 +818,31 @@ fn mat_graph_sync(world: &mut World) {
                     }
                 }
                 GraphEdit::Connect { from_node, from_pin, to_node, to_pin } => {
-                    st.graph.connect(from_node, &from_pin, to_node, &to_pin);
-                    structural = true;
+                    let pin_type = |node_id: u64, pin: &str, dir: PinDir| {
+                        st.graph
+                            .get_node(node_id)
+                            .and_then(|n| node_def(&n.node_type))
+                            .and_then(|d| {
+                                (d.pins)()
+                                    .into_iter()
+                                    .find(|p| p.name == pin && p.direction == dir)
+                            })
+                            .map(|p| p.pin_type)
+                    };
+                    match (
+                        pin_type(from_node, &from_pin, PinDir::Output),
+                        pin_type(to_node, &to_pin, PinDir::Input),
+                    ) {
+                        (Some(from_ty), Some(to_ty)) if !PinType::compatible(from_ty, to_ty) => {
+                            st.compile_errors = vec![format!(
+                                "Connection refused: {from_ty:?} → {to_ty:?} pins are incompatible ({from_pin} → {to_pin})"
+                            )];
+                        }
+                        _ => {
+                            st.graph.connect(from_node, &from_pin, to_node, &to_pin);
+                            structural = true;
+                        }
+                    }
                 }
                 GraphEdit::Disconnect { to_node, to_pin, .. } => {
                     st.graph.disconnect(to_node, &to_pin);

--- a/crates/renzora_material_editor/src/native_graph.rs
+++ b/crates/renzora_material_editor/src/native_graph.rs
@@ -24,7 +24,9 @@ use renzora_ember::reactive::tracked::{bind_2way, bind_display, keyed_list};
 use renzora_ember::theme::*;
 use renzora_ember::widgets::{dropdown, graph_comment_view, graph_node_view, graph_wire_view, icon_button, icon_label_button, node_graph_view, search_menu, GraphEdit, NodeGraphView, SearchEntry};
 use renzora_shader::material::codegen;
-use renzora_shader::material::graph::{MaterialGraph, PinDir, PinTemplate, PinType, PinValue};
+use renzora_shader::material::graph::{
+    resolve_math_ranks, resolved_pin_type, MaterialGraph, PinDir, PinTemplate, PinType, PinValue,
+};
 use renzora_shader::material::material_ref::MaterialRef;
 use renzora_shader::material::nodes::{categories, node_def, nodes_in_category};
 
@@ -422,6 +424,10 @@ fn node_snapshot(world: &Rx, canvas: Entity, viewport: Entity) -> KeyedSnapshot 
         .and_then(|i| s.tabs.get(i))
         .and_then(|t| t.path.as_deref());
     let sel = s.selected_node;
+    // Latched math-node ranks, computed once per snapshot pass: pin colors,
+    // groups and inline editors all read the resolved type, so a node that
+    // latched Vec4 shows Vec4 pins everywhere.
+    let ranks = resolve_math_ranks(&s.graph);
     let nodes: Vec<NodeSnap> = s
         .graph
         .nodes
@@ -431,18 +437,25 @@ fn node_snapshot(world: &Rx, canvas: Entity, viewport: Entity) -> KeyedSnapshot 
             let title = def.map(|d| d.display_name.to_string()).unwrap_or_else(|| n.node_type.clone());
             let color = def.map(|d| (d.color[0], d.color[1], d.color[2])).unwrap_or((90, 90, 100));
             let pins = def.map(|d| (d.pins)()).unwrap_or_default();
-            let inputs: Vec<Port> = pins.iter().filter(|p| p.direction == PinDir::Input).map(|p| (p.name.clone(), p.label.clone(), pin_rgb(p.pin_type), pin_group(p.pin_type))).collect();
-            let outputs: Vec<Port> = pins.iter().filter(|p| p.direction == PinDir::Output).map(|p| (p.name.clone(), p.label.clone(), pin_rgb(p.pin_type), pin_group(p.pin_type))).collect();
+            let ty = |p: &PinTemplate| resolved_pin_type(&ranks, n, &p.name, p.direction).unwrap_or(p.pin_type);
+            let inputs: Vec<Port> = pins.iter().filter(|p| p.direction == PinDir::Input).map(|p| (p.name.clone(), p.label.clone(), pin_rgb(ty(p)), pin_group(ty(p)))).collect();
+            let outputs: Vec<Port> = pins.iter().filter(|p| p.direction == PinDir::Output).map(|p| (p.name.clone(), p.label.clone(), pin_rgb(ty(p)), pin_group(ty(p)))).collect();
             let tex_path = n.input_values.get("texture").and_then(|v| match v {
                 PinValue::TexturePath(p) if !p.is_empty() => Some(p.clone()),
                 _ => None,
             });
             let thumb = tex_path.as_ref().and_then(|p| assets.map(|a| a.load::<Image>(p)));
             let sample_idx = sample_variant_index(&n.node_type);
+            // The inline editor's template carries the *resolved* pin type, so
+            // a latched Vec4 pin mounts a vec4 editor that writes a Vec4 value.
             let in_specs: Vec<(PinTemplate, bool)> = pins
                 .iter()
                 .filter(|p| p.direction == PinDir::Input)
-                .map(|p| ((*p).clone(), wants_editor(&s.graph, n, p)))
+                .map(|p| {
+                    let mut rp = (*p).clone();
+                    rp.pin_type = ty(p);
+                    (rp, wants_editor(&s.graph, n, p))
+                })
                 .collect();
             let error = active_path.zip(problems).and_then(|(path, problems)| {
                 let messages: Vec<&str> = problems
@@ -468,9 +481,10 @@ fn node_snapshot(world: &Rx, canvas: Entity, viewport: Entity) -> KeyedSnapshot 
             // two-way. `sample_idx` is included so switching a sample node's type
             // rebuilds it (new pins + the dropdown's new selection), and the
             // per-input editor flags so wiring a pin makes its inline editor
-            // disappear (and unwiring brings it back), and the compile error so
+            // disappear (and unwiring brings it back), the resolved pin type
+            // so a latch swaps the editor widget, and the compile error so
             // the warning icon appears when it lands and clears when it heals.
-            let editors: Vec<bool> = n.in_specs.iter().map(|(_, e)| *e).collect();
+            let editors: Vec<(PinType, bool)> = n.in_specs.iter().map(|(p, e)| (p.pin_type, *e)).collect();
             (&n.title, n.color, &n.inputs, &n.outputs, &n.tex_path, n.sample_idx, &editors, &n.error).hash(&mut h);
             (k.finish(), h.finish())
         })
@@ -872,16 +886,13 @@ fn mat_graph_sync(world: &mut World) {
                     }
                 }
                 GraphEdit::Connect { from_node, from_pin, to_node, to_pin } => {
+                    // Resolved (latch-aware) types, so the refusal message
+                    // names the type the pin actually behaves as.
+                    let ranks = resolve_math_ranks(&st.graph);
                     let pin_type = |node_id: u64, pin: &str, dir: PinDir| {
                         st.graph
                             .get_node(node_id)
-                            .and_then(|n| node_def(&n.node_type))
-                            .and_then(|d| {
-                                (d.pins)()
-                                    .into_iter()
-                                    .find(|p| p.name == pin && p.direction == dir)
-                            })
-                            .map(|p| p.pin_type)
+                            .and_then(|n| resolved_pin_type(&ranks, n, pin, dir))
                     };
                     match (
                         pin_type(from_node, &from_pin, PinDir::Output),
@@ -1074,13 +1085,18 @@ fn mat_connect_entries(base: [f32; 2], src: (u64, String, bool)) -> Vec<SearchEn
 fn mat_add_and_wire(world: &mut World, node_type: &str, base: [f32; 2], src: (u64, String, bool)) {
     let Some(mut s) = world.get_resource_mut::<MaterialEditorState>() else { return };
     let new_id = s.graph.add_node(node_type, base);
+    // The dragged pin's resolved type, so a wire off a latched Vec4 math node
+    // prefers a Vec4 partner over a bare Float one.
+    let ranks = resolve_math_ranks(&s.graph);
     let src_ty = s
         .graph
         .nodes
         .iter()
         .find(|n| n.id == src.0)
-        .and_then(|n| node_def(&n.node_type))
-        .and_then(|d| (d.pins)().into_iter().find(|p| p.name == src.1).map(|p| p.pin_type));
+        .and_then(|n| {
+            let dir = if src.2 { PinDir::Output } else { PinDir::Input };
+            resolved_pin_type(&ranks, n, &src.1, dir)
+        });
     let want_dir = if src.2 { PinDir::Input } else { PinDir::Output };
     let new_pins = node_def(node_type).map(|d| (d.pins)()).unwrap_or_default();
     let pick = new_pins

--- a/crates/renzora_material_editor/src/native_graph.rs
+++ b/crates/renzora_material_editor/src/native_graph.rs
@@ -929,9 +929,17 @@ fn mat_graph_sync(world: &mut World) {
                         pin_type(to_node, &to_pin, PinDir::Input),
                     ) {
                         (Some(from_ty), Some(to_ty)) if !PinType::compatible(from_ty, to_ty) => {
-                            st.compile_errors = vec![format!(
-                                "Connection refused: {from_ty:?} → {to_ty:?} pins are incompatible ({from_pin} → {to_pin})"
-                            )];
+                            // Not a compile error — those belong to codegen,
+                            // and one sitting in compile_errors freezes the
+                            // preview until the next recompile. The Console
+                            // panel is where the editor's other material
+                            // feedback already goes.
+                            renzora::console_log::console_warn(
+                                "Material",
+                                format!(
+                                    "Connection refused: {from_ty:?} → {to_ty:?} pins are incompatible ({from_pin} → {to_pin})"
+                                ),
+                            );
                         }
                         _ => {
                             st.graph.connect(from_node, &from_pin, to_node, &to_pin);

--- a/crates/renzora_material_editor/src/native_graph.rs
+++ b/crates/renzora_material_editor/src/native_graph.rs
@@ -82,7 +82,7 @@ impl Plugin for NativeMaterialGraph {
         // material graph is the active panel), not inside the panel itself.
         app.add_systems(
             Update,
-            (apply_click, add_node_open, view_op_click, context_menu_open, mat_graph_image_drop, sample_switch_open)
+            (apply_click, save_shortcut, add_node_open, view_op_click, context_menu_open, mat_graph_image_drop, sample_switch_open)
                 .run_if(in_state(SplashState::Editor))
                 .run_if(renzora_ember::dock::panel_active("material_graph")),
         );
@@ -1007,6 +1007,18 @@ fn view_op_click(q: Query<(&Interaction, &ViewOpBtn), Changed<Interaction>>, mut
 
 fn apply_click(q: Query<&Interaction, (With<ApplyBtn>, Changed<Interaction>)>, mut commands: Commands) {
     if q.iter().any(|i| *i == Interaction::Pressed) {
+        commands.queue(crate::apply_material);
+    }
+}
+
+/// Ctrl+S saves the graph — the same path the Apply button takes, because
+/// reaching for a toolbar button every time is impractical. Chord-sharing
+/// with the built-in scene save is deliberate: one keystroke saves
+/// everything. Gated on the graph being the active panel like the other
+/// toolbar systems, so it never fires while the user works elsewhere.
+fn save_shortcut(keys: Res<ButtonInput<KeyCode>>, mut commands: Commands) {
+    let ctrl = keys.pressed(KeyCode::ControlLeft) || keys.pressed(KeyCode::ControlRight);
+    if ctrl && keys.just_pressed(KeyCode::KeyS) {
         commands.queue(crate::apply_material);
     }
 }

--- a/crates/renzora_material_editor/src/native_graph.rs
+++ b/crates/renzora_material_editor/src/native_graph.rs
@@ -885,7 +885,8 @@ fn pending_first_save(world: &mut World, entity: Entity) {
         let _ = std::fs::create_dir_all(&dir);
         let file = dir.join(format!("{}.material", graph_name));
         let mut graph_to_save = world.resource::<MaterialEditorState>().graph.clone();
-        if let Ok((json, _errors)) = renzora_shader::material::precompiled::save_compiled_and_serialize(&mut graph_to_save, &file) {
+        if let Ok((json, report)) = renzora_shader::material::precompiled::save_compiled_and_serialize(&mut graph_to_save, &file) {
+            crate::note_save_warnings(world, &asset_path, &report.warnings);
             let _ = std::fs::write(&file, &json);
             world.resource_mut::<MaterialEditorState>().graph = graph_to_save;
         }

--- a/crates/renzora_material_editor/src/native_graph.rs
+++ b/crates/renzora_material_editor/src/native_graph.rs
@@ -14,8 +14,10 @@ use bevy::ecs::world::CommandQueue;
 use bevy::prelude::*;
 use bevy::ui::{ComputedNode, RelativeCursorPosition, UiTransform};
 
+use renzora::core::keybindings::KeyBinding;
 use renzora::core::CurrentProject;
-use renzora_editor_framework::{AssetDragPayload, DocTabKind, EditorContext, EditorSelection, SplashState};
+use renzora_editor_framework::{AppEditorExt, AssetDragPayload, DocTabKind, EditorContext, EditorSelection, ShortcutEntry, SplashState};
+use renzora_ember::dock::{Dock, DockWindows, FixedDock};
 use renzora_ember::font::{icon_text, ui_font, EmberFonts};
 use renzora_ember::panel::RegisterPanelContent;
 use renzora_ember::reactive::{KeyedSnapshot};
@@ -80,11 +82,39 @@ pub struct NativeMaterialGraph;
 impl Plugin for NativeMaterialGraph {
     fn build(&self, app: &mut App) {
         app.register_panel_content("material_graph", false, build);
+        // Ctrl+S saves the graph through the shortcut registry: rebindable in
+        // Settings → Shortcuts, listed in the command palette, exact-modifier
+        // matched (so Ctrl+Shift+S stays Save Scene As), and skipped while
+        // typing. Chord-sharing with the built-in scene save is deliberate:
+        // one keystroke saves everything.
+        app.register_shortcut(ShortcutEntry::new(
+            "material_graph.save",
+            "Save Material Graph",
+            "File",
+            KeyBinding::new(KeyCode::KeyS).ctrl(),
+            |w| {
+                // The shortcut system scopes globally, not per panel — its
+                // only focus gate is text input. So the panel check rides in
+                // the handler, and it means what `panel_active` means: the
+                // graph is the visible active tab in some dock area. Ctrl+S
+                // typed while another visible panel has the keyboard still
+                // saves this graph, the same way it still saves the scene.
+                let visible = renzora_ember::dock::panel_visible_anywhere(
+                    "material_graph",
+                    w.get_resource::<Dock>(),
+                    w.get_resource::<FixedDock>(),
+                    w.get_resource::<DockWindows>(),
+                );
+                if visible {
+                    crate::apply_material(w);
+                }
+            },
+        ));
         // The graph's actions live in the shared toolbar strip (shown when the
         // material graph is the active panel), not inside the panel itself.
         app.add_systems(
             Update,
-            (apply_click, save_shortcut, add_node_open, view_op_click, context_menu_open, mat_graph_image_drop, sample_switch_open)
+            (apply_click, add_node_open, view_op_click, context_menu_open, mat_graph_image_drop, sample_switch_open)
                 .run_if(in_state(SplashState::Editor))
                 .run_if(renzora_ember::dock::panel_active("material_graph")),
         );
@@ -1018,18 +1048,6 @@ fn view_op_click(q: Query<(&Interaction, &ViewOpBtn), Changed<Interaction>>, mut
 
 fn apply_click(q: Query<&Interaction, (With<ApplyBtn>, Changed<Interaction>)>, mut commands: Commands) {
     if q.iter().any(|i| *i == Interaction::Pressed) {
-        commands.queue(crate::apply_material);
-    }
-}
-
-/// Ctrl+S saves the graph — the same path the Apply button takes, because
-/// reaching for a toolbar button every time is impractical. Chord-sharing
-/// with the built-in scene save is deliberate: one keystroke saves
-/// everything. Gated on the graph being the active panel like the other
-/// toolbar systems, so it never fires while the user works elsewhere.
-fn save_shortcut(keys: Res<ButtonInput<KeyCode>>, mut commands: Commands) {
-    let ctrl = keys.pressed(KeyCode::ControlLeft) || keys.pressed(KeyCode::ControlRight);
-    if ctrl && keys.just_pressed(KeyCode::KeyS) {
         commands.queue(crate::apply_material);
     }
 }

--- a/crates/renzora_material_editor/src/native_inspector.rs
+++ b/crates/renzora_material_editor/src/native_inspector.rs
@@ -23,7 +23,9 @@ use renzora_ember::reactive::Rx;
 use renzora_ember::reactive::tracked::{bind_display, bind_text, keyed_list};
 use renzora_ember::theme::*;
 use renzora_ember::widgets::{bind_text_input, text_input};
-use renzora_shader::material::graph::{PinDir, PinTemplate, PinType};
+use renzora_shader::material::graph::{
+    resolve_math_ranks, resolved_pin_type, PinDir, PinTemplate, PinType,
+};
 use renzora_shader::material::nodes::node_def;
 
 use crate::pin_editors::pin_editor;
@@ -135,7 +137,19 @@ fn node_snapshot(world: &Rx) -> KeyedSnapshot {
     let desc = def.map(|d| d.description).unwrap_or("").to_string();
     let icon = category_icon(category);
     let pins = def.map(|d| (d.pins)()).unwrap_or_default();
-    let input_pins: Vec<PinTemplate> = pins.into_iter().filter(|p| p.direction == PinDir::Input).collect();
+    // Resolved (latch-aware) pin types, so a latched Vec4 math pin shows a
+    // vec4 editor here just like the one on the node.
+    let ranks = resolve_math_ranks(&s.graph);
+    let input_pins: Vec<PinTemplate> = pins
+        .into_iter()
+        .filter(|p| p.direction == PinDir::Input)
+        .map(|mut p| {
+            if let Some(t) = resolved_pin_type(&ranks, node, &p.name, p.direction) {
+                p.pin_type = t;
+            }
+            p
+        })
+        .collect();
     let connected: Vec<String> =
         s.graph.connections.iter().filter(|c| c.to_node == sel).map(|c| c.to_pin.clone()).collect();
 

--- a/crates/renzora_particle_editor/src/native_graph.rs
+++ b/crates/renzora_particle_editor/src/native_graph.rs
@@ -131,8 +131,10 @@ fn tool_button<M: Component>(commands: &mut Commands, fonts: &EmberFonts, icon: 
 
 // ── Snapshots ──────────────────────────────────────────────────────────────────
 
-type Port = (String, String, (u8, u8, u8));
-/// Neutral port colour for particle pins.
+type Port = (String, String, (u8, u8, u8), u32);
+/// Neutral port colour for particle pins. Particle pins are untyped, so they
+/// all share compat group 0 — any pin connects to any pin, as before the
+/// widget grouped ports.
 const PART_PORT: (u8, u8, u8) = (140, 150, 175);
 
 #[allow(clippy::type_complexity)]
@@ -147,8 +149,8 @@ fn node_snapshot(world: &World, canvas: Entity, viewport: Entity) -> KeyedSnapsh
             let title = n.node_type.display_name().to_string();
             let color = cat_color(n.node_type.category());
             let pins = n.node_type.pins();
-            let inputs: Vec<Port> = pins.iter().filter(|p| p.direction == PinDir::Input).map(|p| (p.name.clone(), p.label.clone(), PART_PORT)).collect();
-            let outputs: Vec<Port> = pins.iter().filter(|p| p.direction == PinDir::Output).map(|p| (p.name.clone(), p.label.clone(), PART_PORT)).collect();
+            let inputs: Vec<Port> = pins.iter().filter(|p| p.direction == PinDir::Input).map(|p| (p.name.clone(), p.label.clone(), PART_PORT, 0)).collect();
+            let outputs: Vec<Port> = pins.iter().filter(|p| p.direction == PinDir::Output).map(|p| (p.name.clone(), p.label.clone(), PART_PORT, 0)).collect();
             (n.id, title, color, n.position, inputs, outputs, sel == Some(n.id))
         })
         .collect();

--- a/crates/renzora_postprocess/Cargo.toml
+++ b/crates/renzora_postprocess/Cargo.toml
@@ -28,7 +28,7 @@ renzora_plugin = { path = "../renzora_plugin", features = ["host"] }
 # Used ONLY to validate a plugin's shader before handing it to wgpu. Without
 # this, a layout mismatch in third-party WGSL is an unrecoverable GPU panic
 # rather than an error message.
-naga = { version = "27", features = ["wgsl-in"] }
+naga = { version = "29", features = ["wgsl-in"] }
 
 [lints]
 workspace = true

--- a/crates/renzora_postprocess/src/plugin_bridge.rs
+++ b/crates/renzora_postprocess/src/plugin_bridge.rs
@@ -687,7 +687,7 @@ fn build_effect(
 ///
 /// Returns `Err` with a message meant for the plugin author, not for us.
 fn validate_effect_shader(wgsl: &str, expected: u64) -> Result<(), String> {
-    let module = naga::front::wgsl::parse_str(wgsl)
+    let module = renzora::wgsl::parse(wgsl)
         .map_err(|e| format!("shader does not parse: {}", e.message()))?;
     let mut layouter = naga::proc::Layouter::default();
     layouter

--- a/crates/renzora_shader/Cargo.toml
+++ b/crates/renzora_shader/Cargo.toml
@@ -10,9 +10,18 @@ editor = []
 bevy = { workspace = true }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-naga = { version = "27", features = ["wgsl-in", "wgsl-out", "glsl-in"] }
+naga = { version = "29", features = ["wgsl-in", "wgsl-out", "glsl-in"] }
 uuid = { version = "1", features = ["v4"] }
 renzora = { path = "../renzora", default-features = false }
+# The composer Bevy resolves `#import` with. Pinned to what `bevy_shader` links
+# — a second version would be a second definition of `#import`, which is the
+# thing this crate's validator exists to avoid.
+naga_oil = "0.22"
+
+[dev-dependencies]
+# An App is how you get at `Assets<Shader>`, which is where bevy_pbr keeps the
+# sources the validator composes against.
+renzora_test_harness = { path = "../renzora_test_harness" }
 
 [lints]
 workspace = true

--- a/crates/renzora_shader/Cargo.toml
+++ b/crates/renzora_shader/Cargo.toml
@@ -22,6 +22,10 @@ naga_oil = "0.22"
 # An App is how you get at `Assets<Shader>`, which is where bevy_pbr keeps the
 # sources the validator composes against.
 renzora_test_harness = { path = "../renzora_test_harness" }
+# Tests exercise the Problems-panel validator, which is `editor`-gated; a self
+# dev-dependency turns the feature on for test builds without enabling it for
+# downstream (shipped-game) builds.
+renzora_shader = { path = ".", features = ["editor"] }
 
 [lints]
 workspace = true

--- a/crates/renzora_shader/src/material/codegen.rs
+++ b/crates/renzora_shader/src/material/codegen.rs
@@ -173,6 +173,7 @@ struct Ctx<'a> {
     /// look up an already-allocated slot in O(1) when the same parameter
     /// name appears on multiple nodes.
     parameter_slots: HashMap<String, usize>,
+    warnings: Vec<String>,
 }
 
 impl<'a> Ctx<'a> {
@@ -223,6 +224,7 @@ impl<'a> Ctx<'a> {
             in_displacement_fn: false,
             parameters: Vec::new(),
             parameter_slots: HashMap::new(),
+            warnings: Vec::new(),
         }
     }
 
@@ -241,6 +243,15 @@ impl<'a> Ctx<'a> {
             // Once we hit the cap, every subsequent unique name aliases the
             // last slot. We still record the parameter so tooling can list
             // it, but the actual reads will collide.
+            self.warnings.push(format!(
+                "parameter '{name}' exceeds the {MAX_PARAMETER_SLOTS}-slot parameter buffer; \
+                 it aliases slot {} and will read as '{}'. Split the material or reuse names.",
+                MAX_PARAMETER_SLOTS - 1,
+                self.parameters
+                    .last()
+                    .map(|p| p.name.as_str())
+                    .unwrap_or("?"),
+            ));
             return MAX_PARAMETER_SLOTS - 1;
         }
         self.parameters.push(MaterialParam {
@@ -328,7 +339,13 @@ impl<'a> Ctx<'a> {
         if let Some(def) = nodes::node_def(&node.node_type) {
             let pins = (def.pins)();
             if let Some(pin) = pins.iter().find(|p| p.name == pin_name) {
-                return pin.default_value.to_wgsl();
+                let expr = pin.default_value.to_wgsl();
+                // A pin with no default falls back to a plain `0.0`, so a Vec3 pin gets a float unless we widen it.
+                let vt = pin.default_value.pin_type();
+                if vt != pin.pin_type {
+                    return graph::PinType::cast_expr(vt, pin.pin_type, &expr);
+                }
+                return expr;
             }
         }
 
@@ -626,7 +643,7 @@ impl<'a> Ctx<'a> {
                 self.set_out(id, "position", "view.world_position.xyz".into());
             }
             "input/object_position" => {
-                // mesh_functions provides mesh[in.instance_index]
+                // Column 3 of the model matrix is the object's world-space translation.
                 self.set_out(
                     id,
                     "position",
@@ -1075,11 +1092,13 @@ impl<'a> Ctx<'a> {
 
                 let w = self.next_var("tri_w");
                 let v = self.next_var("tri");
+                // `var`, not `let` — WGSL has no shadowing, so the next line has to assign, not redeclare.
                 self.emit(format!(
-                    "    let {w} = pow(abs(in.world_normal), vec3<f32>({sharpness}));"
+                    "    var {w} = pow(abs(in.world_normal), vec3<f32>({sharpness}));"
                 ));
-                self.emit(format!("    let {w} = {w} / ({w}.x + {w}.y + {w}.z);"));
-                let p = format!("in.world_position.xyz * {scale}");
+                self.emit(format!("    {w} = {w} / ({w}.x + {w}.y + {w}.z);"));
+                // Brackets, or `.yz` below attaches to the last operand instead of the whole product.
+                let p = format!("(in.world_position.xyz * {scale})");
                 self.emit(format!("    let {v} = textureSample({tex_name}, texture_sampler, {p}.yz) * {w}.x + textureSample({tex_name}, texture_sampler, {p}.xz) * {w}.y + textureSample({tex_name}, texture_sampler, {p}.xy) * {w}.z;"));
                 self.set_out(id, "color", v.clone());
                 self.set_out(id, "rgb", format!("{v}.rgb"));
@@ -2314,10 +2333,10 @@ impl<'a> Ctx<'a> {
                 let dir = self.input(node, "direction");
                 let mip = self.input(node, "mip_level");
                 let v = self.next_var("env");
-                // Guarded for Bevy's two env-map binding variants. We only
-                // emit the sampling code itself; the bindings are imported
-                // from bevy_pbr::mesh_view_bindings (which Bevy already
-                // binds for every camera with a view bind group).
+                // No ENVIRONMENT_MAP means no binding at all, so a camera with
+                // no environment map light needs the fallback below or the
+                // material fails to compile for it.
+                self.emit("#ifdef ENVIRONMENT_MAP".to_string());
                 self.emit("#ifdef MULTIPLE_LIGHT_PROBES_IN_ARRAY".to_string());
                 self.emit(format!(
                     "    let {v} = textureSampleLevel(specular_environment_maps[0], environment_map_sampler, normalize({dir}), {mip});"
@@ -2326,6 +2345,9 @@ impl<'a> Ctx<'a> {
                 self.emit(format!(
                     "    let {v} = textureSampleLevel(specular_environment_map, environment_map_sampler, normalize({dir}), {mip});"
                 ));
+                self.emit("#endif".to_string());
+                self.emit("#else".to_string());
+                self.emit(format!("    let {v} = vec4<f32>(0.0, 0.0, 0.0, 1.0);"));
                 self.emit("#endif".to_string());
                 self.set_out(id, "color", v.clone());
                 self.set_out(id, "rgb", format!("{v}.rgb"));
@@ -2344,6 +2366,8 @@ impl<'a> Ctx<'a> {
                 self.emit(format!(
                     "    let {v}_rd = reflect(-{v}_vd, normalize({n}));"
                 ));
+                // Same fallback as `scene/env_map_sample` — see there.
+                self.emit("#ifdef ENVIRONMENT_MAP".to_string());
                 self.emit("#ifdef MULTIPLE_LIGHT_PROBES_IN_ARRAY".to_string());
                 self.emit(format!(
                     "    let {v} = textureSampleLevel(specular_environment_maps[0], environment_map_sampler, {v}_rd, {mip});"
@@ -2352,6 +2376,9 @@ impl<'a> Ctx<'a> {
                 self.emit(format!(
                     "    let {v} = textureSampleLevel(specular_environment_map, environment_map_sampler, {v}_rd, {mip});"
                 ));
+                self.emit("#endif".to_string());
+                self.emit("#else".to_string());
+                self.emit(format!("    let {v} = vec4<f32>(0.0, 0.0, 0.0, 1.0);"));
                 self.emit("#endif".to_string());
                 self.set_out(id, "color", v.clone());
                 self.set_out(id, "rgb", format!("{v}.rgb"));
@@ -2584,7 +2611,7 @@ pub fn compile_with_functions(
         texture_bindings: ctx.texture_bindings,
         domain: graph.domain,
         errors,
-        warnings: Vec::new(),
+        warnings: ctx.warnings,
         requires_transmission,
         parameters: ctx.parameters,
     }
@@ -3114,6 +3141,7 @@ fn emit_ext_shader_header(ctx: &Ctx, shader: &mut String) {
     shader.push_str("#import bevy_pbr::forward_io::{VertexOutput, FragmentOutput}\n");
     shader.push_str("#import bevy_pbr::mesh_view_bindings::{view, globals}\n");
 
+    shader.push_str("#import bevy_pbr::mesh_functions\n");
     if ctx.uses_scene_depth || ctx.uses_scene_normal || ctx.uses_motion_vector {
         shader.push_str("#import bevy_pbr::prepass_utils\n");
     }
@@ -3121,10 +3149,12 @@ fn emit_ext_shader_header(ctx: &Ctx, shader: &mut String) {
         shader.push_str("#import bevy_pbr::mesh_view_bindings::{view_transmission_texture, view_transmission_sampler}\n");
     }
     if ctx.uses_env_map {
+        shader.push_str("#ifdef ENVIRONMENT_MAP\n");
         shader.push_str("#ifdef MULTIPLE_LIGHT_PROBES_IN_ARRAY\n");
         shader.push_str("#import bevy_pbr::mesh_view_bindings::{specular_environment_maps, environment_map_sampler}\n");
         shader.push_str("#else\n");
         shader.push_str("#import bevy_pbr::mesh_view_bindings::{specular_environment_map, environment_map_sampler}\n");
+        shader.push_str("#endif\n");
         shader.push_str("#endif\n");
     }
     shader.push('\n');

--- a/crates/renzora_shader/src/material/codegen.rs
+++ b/crates/renzora_shader/src/material/codegen.rs
@@ -189,6 +189,10 @@ struct Ctx<'a> {
     /// `(node, 0-based start line in the concatenated prelude, line count)`.
     prelude_spans: Vec<(NodeId, u32, u32)>,
     prelude_line_count: u32,
+    /// Latched vectorization rank per `math/*` node (see
+    /// [`graph::resolve_math_ranks`]). Swapped alongside `graph` when a
+    /// material function's internal graph is compiled.
+    math_ranks: HashMap<NodeId, graph::PinType>,
 }
 
 impl<'a> Ctx<'a> {
@@ -244,6 +248,7 @@ impl<'a> Ctx<'a> {
             body_spans: Vec::new(),
             prelude_spans: Vec::new(),
             prelude_line_count: 0,
+            math_ranks: graph::resolve_math_ranks(graph),
         }
     }
 
@@ -292,24 +297,29 @@ impl<'a> Ctx<'a> {
         self.output_vars.insert((node, pin.to_string()), expr);
     }
 
-    /// Look up the PinType for a given pin on a node definition.
+    /// Look up the PinType a pin behaves as — the latched vectorization rank
+    /// for a dynamic math pin, the declared template type for the rest.
     fn pin_type_for(
-        node_type: &str,
+        &self,
+        node: &MaterialNode,
         pin_name: &str,
         direction: graph::PinDir,
     ) -> Option<graph::PinType> {
-        let def = nodes::node_def(node_type)?;
-        let pins = (def.pins)();
-        pins.iter()
-            .find(|p| p.name == pin_name && p.direction == direction)
-            .map(|p| p.pin_type)
+        graph::resolved_pin_type(&self.math_ranks, node, pin_name, direction)
+    }
+
+    /// The math node's latched rank (Float when nothing is wired to it).
+    /// Every `math/*` node names its output pin `result`.
+    fn math_rank(&self, node: &MaterialNode) -> graph::PinType {
+        self.pin_type_for(node, "result", graph::PinDir::Output)
+            .unwrap_or(graph::PinType::Float)
     }
 
     /// Resolve an input pin value — follows connections or falls back to defaults.
     /// Applies automatic type coercion (e.g. Float → Vec4) when pin types differ.
     fn input(&mut self, node: &MaterialNode, pin_name: &str) -> String {
         // Determine expected type of destination pin
-        let dest_type = Self::pin_type_for(&node.node_type, pin_name, graph::PinDir::Input);
+        let dest_type = self.pin_type_for(node, pin_name, graph::PinDir::Input);
 
         // Check for connection
         if let Some(conn) = self.graph.connection_to(node.id, pin_name) {
@@ -328,8 +338,7 @@ impl<'a> Ctx<'a> {
             {
                 // Apply type coercion if source and dest types differ
                 if let (Some(dt), Some(src_node)) = (dest_type, self.graph.get_node(from_node)) {
-                    if let Some(st) =
-                        Self::pin_type_for(&src_node.node_type, &from_pin, graph::PinDir::Output)
+                    if let Some(st) = self.pin_type_for(src_node, &from_pin, graph::PinDir::Output)
                     {
                         return graph::PinType::cast_expr(st, dt, &expr);
                     }
@@ -359,16 +368,34 @@ impl<'a> Ctx<'a> {
             let pins = (def.pins)();
             if let Some(pin) = pins.iter().find(|p| p.name == pin_name) {
                 let expr = pin.default_value.to_wgsl();
-                // A pin with no default falls back to a plain `0.0`, so a Vec3 pin gets a float unless we widen it.
+                // A pin with no default falls back to a plain `0.0`, so a Vec3
+                // pin gets a float unless we widen it. The cast target is the
+                // *resolved* type, not the template's: a dynamic math pin
+                // declares Float even after the node latched wider, and an
+                // unwired `b` on a Vec4 Add would otherwise compose
+                // `vec4 + f32`.
                 let vt = pin.default_value.pin_type();
-                if vt != pin.pin_type {
-                    return graph::PinType::cast_expr(vt, pin.pin_type, &expr);
+                let dt = dest_type.unwrap_or(pin.pin_type);
+                if vt != dt {
+                    return graph::PinType::cast_expr(vt, dt, &expr);
                 }
                 return expr;
             }
         }
 
         "0.0".to_string()
+    }
+
+    /// A scalar guard literal at a math node's latched rank: plain for Float,
+    /// a splat `vecN<f32>(lit)` constructor for vectors. Deliberately not
+    /// `cast_expr(Float, rank, …)` — its Vec4 widening fills w with `1.0`,
+    /// which would clamp the guard's last component against 1.0 instead of
+    /// the epsilon and change what the guard protects.
+    fn guard_lit(t: graph::PinType, lit: &str) -> String {
+        match t {
+            graph::PinType::Float => lit.to_string(),
+            other => format!("{}({lit})", other.wgsl_type()),
+        }
     }
 
     fn emit(&mut self, line: String) {
@@ -505,6 +532,8 @@ impl<'a> Ctx<'a> {
 
         // Swap outer graph state for the function's local state.
         let saved_graph = std::mem::replace(&mut self.graph, &mat_fn.graph);
+        let saved_ranks =
+            std::mem::replace(&mut self.math_ranks, graph::resolve_math_ranks(&mat_fn.graph));
         let saved_lines = std::mem::take(&mut self.lines);
         let saved_output_vars = std::mem::take(&mut self.output_vars);
         let saved_processed = std::mem::take(&mut self.processed);
@@ -534,6 +563,7 @@ impl<'a> Ctx<'a> {
         self.output_vars = saved_output_vars;
         self.processed = saved_processed;
         self.graph = saved_graph;
+        self.math_ranks = saved_ranks;
 
         // Stitch into a WGSL function.
         let mut s = String::new();
@@ -1167,8 +1197,9 @@ impl<'a> Ctx<'a> {
             "math/divide" => {
                 let a = self.input(node, "a");
                 let b = self.input(node, "b");
+                let eps = Self::guard_lit(self.math_rank(node), "0.000001");
                 let v = self.next_var("div");
-                self.emit(format!("    let {v} = {a} / max({b}, 0.000001);"));
+                self.emit(format!("    let {v} = {a} / max({b}, {eps});"));
                 self.set_out(id, "result", v);
             }
             "math/power" => {
@@ -1192,8 +1223,9 @@ impl<'a> Ctx<'a> {
             }
             "math/one_minus" => {
                 let val = self.input(node, "value");
+                let one = Self::guard_lit(self.math_rank(node), "1.0");
                 let v = self.next_var("om");
-                self.emit(format!("    let {v} = 1.0 - {val};"));
+                self.emit(format!("    let {v} = {one} - {val};"));
                 self.set_out(id, "result", v);
             }
             "math/fract" => {
@@ -1265,8 +1297,9 @@ impl<'a> Ctx<'a> {
                 let in_max = self.input(node, "in_max");
                 let out_min = self.input(node, "out_min");
                 let out_max = self.input(node, "out_max");
+                let eps = Self::guard_lit(self.math_rank(node), "0.000001");
                 let v = self.next_var("remap");
-                self.emit(format!("    let {v} = {out_min} + ({val} - {in_min}) / max({in_max} - {in_min}, 0.000001) * ({out_max} - {out_min});"));
+                self.emit(format!("    let {v} = {out_min} + ({val} - {in_min}) / max({in_max} - {in_min}, {eps}) * ({out_max} - {out_min});"));
                 self.set_out(id, "result", v);
             }
             "math/sin" => {
@@ -1290,9 +1323,10 @@ impl<'a> Ctx<'a> {
             "math/modulo" => {
                 let a = self.input(node, "a");
                 let b = self.input(node, "b");
+                let eps = Self::guard_lit(self.math_rank(node), "0.000001");
                 let v = self.next_var("mod");
                 self.emit(format!(
-                    "    let {v} = {a} - {b} * floor({a} / max({b}, 0.000001));"
+                    "    let {v} = {a} - {b} * floor({a} / max({b}, {eps}));"
                 ));
                 self.set_out(id, "result", v);
             }
@@ -1329,20 +1363,25 @@ impl<'a> Ctx<'a> {
             }
             "math/log" => {
                 let val = self.input(node, "value");
+                let eps = Self::guard_lit(self.math_rank(node), "0.000001");
                 let v = self.next_var("log");
-                self.emit(format!("    let {v} = log(max({val}, 0.000001));"));
+                self.emit(format!("    let {v} = log(max({val}, {eps}));"));
                 self.set_out(id, "result", v);
             }
             "math/sqrt" => {
                 let val = self.input(node, "value");
+                let zero = Self::guard_lit(self.math_rank(node), "0.0");
                 let v = self.next_var("sqrt");
-                self.emit(format!("    let {v} = sqrt(max({val}, 0.0));"));
+                self.emit(format!("    let {v} = sqrt(max({val}, {zero}));"));
                 self.set_out(id, "result", v);
             }
             "math/reciprocal" => {
                 let val = self.input(node, "value");
+                let rt = self.math_rank(node);
+                let one = Self::guard_lit(rt, "1.0");
+                let eps = Self::guard_lit(rt, "0.000001");
                 let v = self.next_var("rcp");
-                self.emit(format!("    let {v} = 1.0 / max({val}, 0.000001);"));
+                self.emit(format!("    let {v} = {one} / max({val}, {eps});"));
                 self.set_out(id, "result", v);
             }
             "math/tan" => {
@@ -1353,14 +1392,20 @@ impl<'a> Ctx<'a> {
             }
             "math/asin" => {
                 let val = self.input(node, "value");
+                let rt = self.math_rank(node);
+                let lo = Self::guard_lit(rt, "-1.0");
+                let hi = Self::guard_lit(rt, "1.0");
                 let v = self.next_var("asin");
-                self.emit(format!("    let {v} = asin(clamp({val}, -1.0, 1.0));"));
+                self.emit(format!("    let {v} = asin(clamp({val}, {lo}, {hi}));"));
                 self.set_out(id, "result", v);
             }
             "math/acos" => {
                 let val = self.input(node, "value");
+                let rt = self.math_rank(node);
+                let lo = Self::guard_lit(rt, "-1.0");
+                let hi = Self::guard_lit(rt, "1.0");
                 let v = self.next_var("acos");
-                self.emit(format!("    let {v} = acos(clamp({val}, -1.0, 1.0));"));
+                self.emit(format!("    let {v} = acos(clamp({val}, {lo}, {hi}));"));
                 self.set_out(id, "result", v);
             }
             "math/radians" => {
@@ -3846,7 +3891,12 @@ mod tests {
         }
 
         let shader = compile(&graph).fragment_shader;
-        assert!(shader.contains("perceptual_roughness = 0.250000"));
+        // `to_wgsl` wraps floats in `f32(..)` so naga never faces a bare
+        // abstract literal; the point is the assignment carries no `*` factor.
+        assert!(
+            shader.contains("perceptual_roughness = f32(0.250000);"),
+            "unwired constant must pass straight through:\n{shader}"
+        );
     }
 
     /// A normal map decodes to tangent space, but the Surface Output `normal`

--- a/crates/renzora_shader/src/material/codegen.rs
+++ b/crates/renzora_shader/src/material/codegen.rs
@@ -3479,9 +3479,7 @@ fn build_pbr_shader(
     // on a tint.
     if is_connected("attenuation_color") {
         let e = resolved.get("attenuation_color").unwrap();
-        shader.push_str(&format!(
-            "    pbr_input.material.attenuation_color = vec4<f32>({e}, 1.0);\n"
-        ));
+        mutations.push((feeder("attenuation_color"), format!("    pbr_input.material.attenuation_color = vec4<f32>({e}, 1.0);")));
     }
 
     // ── Clearcoat (car paint, lacquer) ────────────────────────────────

--- a/crates/renzora_shader/src/material/codegen.rs
+++ b/crates/renzora_shader/src/material/codegen.rs
@@ -64,6 +64,12 @@ pub struct CompileResult {
     /// is the master's authored default value; material instances supply
     /// per-instance overrides keyed by name.
     pub parameters: Vec<MaterialParam>,
+    /// Which node authored which lines of `fragment_shader`:
+    /// `(node id, first line, last line)`, 1-based, sorted by node id.
+    /// Header and helper lines appear in no range — an error there is an
+    /// engine bug, not a user bug. This is what lets compile errors point
+    /// at a node instead of a line nobody can see.
+    pub node_lines: Vec<(u64, u32, u32)>,
 }
 
 /// One named graph-boundary parameter discovered by the compiler.
@@ -174,6 +180,15 @@ struct Ctx<'a> {
     /// name appears on multiple nodes.
     parameter_slots: HashMap<String, usize>,
     warnings: Vec<String>,
+    /// Node whose lines are currently being emitted. Save/restored around
+    /// `gen_node` — `input()` recurses upstream and would otherwise leave a
+    /// node's own lines attributed to whatever it last pulled from.
+    current_node: NodeId,
+    /// `(node, 0-based index into `lines`)` for every emitted body line.
+    body_spans: Vec<(NodeId, u32)>,
+    /// `(node, 0-based start line in the concatenated prelude, line count)`.
+    prelude_spans: Vec<(NodeId, u32, u32)>,
+    prelude_line_count: u32,
 }
 
 impl<'a> Ctx<'a> {
@@ -225,6 +240,10 @@ impl<'a> Ctx<'a> {
             parameters: Vec::new(),
             parameter_slots: HashMap::new(),
             warnings: Vec::new(),
+            current_node: 0,
+            body_spans: Vec::new(),
+            prelude_spans: Vec::new(),
+            prelude_line_count: 0,
         }
     }
 
@@ -353,7 +372,20 @@ impl<'a> Ctx<'a> {
     }
 
     fn emit(&mut self, line: String) {
+        self.body_spans.push((self.current_node, self.lines.len() as u32));
         self.lines.push(line);
+    }
+
+    /// Push a module-scope chunk, recording which node authored it and how
+    /// many lines it adds. `module_prelude` bypasses `emit`, and it is where
+    /// `custom/code` snippets live — the lines users most often break.
+    fn emit_prelude(&mut self, chunk: String) {
+        let lines =
+            chunk.matches('\n').count() as u32 + u32::from(!chunk.ends_with('\n'));
+        self.prelude_spans
+            .push((self.current_node, self.prelude_line_count, lines));
+        self.prelude_line_count += lines;
+        self.module_prelude.push(chunk);
     }
 
     /// Emit a triplanar-sampled FBM-family noise. The shared shape:
@@ -527,6 +559,12 @@ impl<'a> Ctx<'a> {
             return;
         }
         self.processed.insert(node.id);
+        let prev_node = std::mem::replace(&mut self.current_node, node.id);
+        self.gen_node_body(node);
+        self.current_node = prev_node;
+    }
+
+    fn gen_node_body(&mut self, node: &MaterialNode) {
         let id = node.id;
 
         match node.node_type.as_str() {
@@ -2085,7 +2123,7 @@ impl<'a> Ctx<'a> {
                 // generated helper. Each node id is unique and generated once,
                 // so the helper is emitted exactly once with no dedup needed.
                 let fn_name = format!("mat_custom_{id}");
-                self.module_prelude.push(format!(
+                self.emit_prelude(format!(
                     "fn {fn_name}(a: vec4<f32>, b: vec4<f32>, c: vec4<f32>, d: vec4<f32>) -> vec4<f32> {{\n    var result: vec4<f32> = vec4<f32>(0.0, 0.0, 0.0, 1.0);\n    {code}\n    return result;\n}}"
                 ));
                 let res = self.next_var("custom");
@@ -2442,7 +2480,7 @@ impl<'a> Ctx<'a> {
                                 self.compiling_functions.insert(fn_name.clone());
                                 let fn_wgsl = self.compile_function_body(mat_fn);
                                 self.compiling_functions.remove(&fn_name);
-                                self.module_prelude.push(fn_wgsl);
+                                self.emit_prelude(fn_wgsl);
                                 self.emitted_functions.insert(fn_name.clone());
                             }
                             None => {
@@ -2507,6 +2545,7 @@ pub fn compile_with_functions(
                 warnings: Vec::new(),
                 requires_transmission: false,
                 parameters: Vec::new(),
+                node_lines: Vec::new(),
             };
         }
     };
@@ -2587,7 +2626,7 @@ pub fn compile_with_functions(
     }
 
     // Build the full shader
-    let fragment_shader = match graph.domain {
+    let (fragment_shader, node_lines) = match graph.domain {
         MaterialDomain::Surface | MaterialDomain::Vegetation => {
             build_pbr_shader(&ctx, &resolved, graph.domain)
         }
@@ -2614,6 +2653,7 @@ pub fn compile_with_functions(
         warnings: ctx.warnings,
         requires_transmission,
         parameters: ctx.parameters,
+        node_lines,
     }
 }
 
@@ -2993,7 +3033,58 @@ fn mat_blend(base: vec4<f32>, blnd: vec4<f32>, opacity: f32, mode: i32) -> vec4<
 fn emit_module_prelude(ctx: &Ctx, s: &mut String) {
     for chunk in &ctx.module_prelude {
         s.push_str(chunk);
+        // Chunks carry no trailing newline of their own; without one the
+        // next chunk's `fn` glues onto this chunk's closing brace.
+        if !chunk.ends_with('\n') {
+            s.push('\n');
+        }
     }
+}
+
+/// Merge the per-line spans recorded during emission into per-node absolute
+/// ranges. `prelude_base` / `body_base` are the 1-based absolute lines the
+/// first prelude / body line lands on in the assembled shader; `extra`
+/// covers builder-tail lines (the PbrInput mutation block) whose absolute
+/// positions only the builder knows.
+fn node_line_ranges(
+    ctx: &Ctx,
+    prelude_base: u32,
+    body_base: u32,
+    extra: &[(NodeId, u32, u32)],
+) -> Vec<(u64, u32, u32)> {
+    let mut ranges: HashMap<NodeId, (u32, u32)> = HashMap::new();
+    let mut extend = |node: NodeId, start: u32, end: u32| {
+        let r = ranges.entry(node).or_insert((start, end));
+        r.0 = r.0.min(start);
+        r.1 = r.1.max(end);
+    };
+    for &(node, idx) in &ctx.body_spans {
+        extend(node, body_base + idx, body_base + idx);
+    }
+    for &(node, start, count) in &ctx.prelude_spans {
+        extend(node, prelude_base + start, prelude_base + start + count - 1);
+    }
+    for &(node, start, end) in extra {
+        extend(node, start, end);
+    }
+    let mut ranges: Vec<(u64, u32, u32)> = ranges
+        .into_iter()
+        .map(|(node, (start, end))| (node, start, end))
+        .collect();
+    ranges.sort_unstable();
+    ranges
+}
+
+/// Which node authored `line` (1-based) of the generated shader — the
+/// innermost range containing it, since a node nested inside another's
+/// lines is the more specific answer. `None` for header/helper lines, which
+/// no node authored; an error there is an engine bug, not a user bug.
+pub fn node_for_line(node_lines: &[(u64, u32, u32)], line: u32) -> Option<u64> {
+    node_lines
+        .iter()
+        .filter(|(_, start, end)| *start <= line && line <= *end)
+        .max_by_key(|(_, start, _)| *start)
+        .map(|(node, _, _)| *node)
 }
 
 /// WGSL snippet that aliases mesh-conditional VertexOutput fields. Generated
@@ -3177,7 +3268,7 @@ fn build_pbr_shader(
     ctx: &Ctx,
     resolved: &HashMap<String, String>,
     _domain: MaterialDomain,
-) -> String {
+) -> (String, Vec<(u64, u32, u32)>) {
     let output_node = ctx.graph.output_node().unwrap();
     let output_id = output_node.id;
     // A pin is considered "set" when the user either connected a graph to it
@@ -3235,6 +3326,7 @@ fn build_pbr_shader(
     emit_ext_shader_header(ctx, &mut shader);
     shader.push_str(&texture_bindings_wgsl(ctx));
     shader.push_str(&noise_helpers(ctx));
+    let prelude_base = shader.matches('\n').count() as u32 + 1;
     emit_module_prelude(ctx, &mut shader);
 
     shader.push_str("\n@fragment\n");
@@ -3254,6 +3346,7 @@ fn build_pbr_shader(
     }
 
     // Graph body — runs between the StandardMaterial init and the mutations.
+    let body_base = shader.matches('\n').count() as u32 + 1;
     for line in &ctx.lines {
         shader.push_str(line);
         shader.push('\n');
@@ -3262,42 +3355,43 @@ fn build_pbr_shader(
     // Override pbr_input fields for each pin the user wired up. Disconnected
     // pins leave StandardMaterial's defaults in place, so authors can partially
     // override (e.g. only procedural roughness, keeping base_color from the
-    // StandardMaterial's texture).
+    // StandardMaterial's texture). Each mutation line attributes to the node
+    // feeding the pin — a bad expression fails *here*, not where it was built.
     shader.push_str("\n    // Graph → PbrInput mutations\n");
+    let feeder = |pin: &str| {
+        ctx.graph
+            .connection_to(output_id, pin)
+            .map(|c| c.from_node)
+            .unwrap_or(output_id)
+    };
+    let mut mutations: Vec<(NodeId, String)> = Vec::new();
     if is_connected("base_color") {
         let e = resolved.get("base_color").unwrap();
         let e = scaled("base_color", e, 4);
-        shader.push_str(&format!("    pbr_input.material.base_color = {e};\n"));
+        mutations.push((feeder("base_color"), format!("    pbr_input.material.base_color = {e};")));
     }
     if is_connected("metallic") {
         let e = resolved.get("metallic").unwrap();
         let e = scaled("metallic", e, 1);
-        shader.push_str(&format!("    pbr_input.material.metallic = {e};\n"));
+        mutations.push((feeder("metallic"), format!("    pbr_input.material.metallic = {e};")));
     }
     if is_connected("roughness") {
         let e = resolved.get("roughness").unwrap();
         let e = scaled("roughness", e, 1);
-        shader.push_str(&format!(
-            "    pbr_input.material.perceptual_roughness = {e};\n"
-        ));
+        mutations.push((feeder("roughness"), format!("    pbr_input.material.perceptual_roughness = {e};")));
     }
     if is_connected("emissive") {
         let e = resolved.get("emissive").unwrap();
         let e = scaled("emissive", e, 3);
-        shader.push_str(&format!(
-            "    pbr_input.material.emissive = vec4<f32>({e}, 1.0);\n"
-        ));
+        mutations.push((feeder("emissive"), format!("    pbr_input.material.emissive = vec4<f32>({e}, 1.0);")));
     }
     if is_connected("ao") {
         let e = resolved.get("ao").unwrap();
-        shader.push_str(&format!(
-            "    pbr_input.diffuse_occlusion = vec3<f32>({e});\n"
-        ));
+        mutations.push((feeder("ao"), format!("    pbr_input.diffuse_occlusion = vec3<f32>({e});")));
     }
     if is_connected("normal") {
         let e = resolved.get("normal").unwrap();
-        shader.push_str(&format!("    pbr_input.N = normalize({e});\n"));
-        shader.push_str("    pbr_input.world_normal = pbr_input.N;\n");
+        mutations.push((feeder("normal"), format!("    pbr_input.N = normalize({e});\n    pbr_input.world_normal = pbr_input.N;")));
     }
     if is_connected("alpha") {
         let e = resolved.get("alpha").unwrap();
@@ -3305,42 +3399,35 @@ fn build_pbr_shader(
         // on this pin. A clear-coat authored at 0.243 that ignores its factor
         // renders solid and hides whatever it was meant to sit over.
         let e = scaled("alpha", e, 1);
-        shader.push_str(&format!("    pbr_input.material.base_color.a = {e};\n"));
+        mutations.push((feeder("alpha"), format!("    pbr_input.material.base_color.a = {e};")));
     }
     if is_connected("reflectance") {
         let e = resolved.get("reflectance").unwrap();
-        shader.push_str(&format!("    pbr_input.material.reflectance = {e};\n"));
+        mutations.push((feeder("reflectance"), format!("    pbr_input.material.reflectance = {e};")));
     }
-
     // ── Transmission (water, glass, ice) ──────────────────────────────
     // `specular_transmission > 0` on the CPU-side StandardMaterial is what
     // triggers Bevy to schedule its transmissive pass. The resolver takes
     // care of setting the CPU-side flag (see `requires_transmission`).
     if is_connected("specular_transmission") {
         let e = resolved.get("specular_transmission").unwrap();
-        shader.push_str(&format!(
-            "    pbr_input.material.specular_transmission = {e};\n"
-        ));
+        mutations.push((feeder("specular_transmission"), format!("    pbr_input.material.specular_transmission = {e};")));
     }
     if is_connected("diffuse_transmission") {
         let e = resolved.get("diffuse_transmission").unwrap();
-        shader.push_str(&format!(
-            "    pbr_input.material.diffuse_transmission = {e};\n"
-        ));
+        mutations.push((feeder("diffuse_transmission"), format!("    pbr_input.material.diffuse_transmission = {e};")));
     }
     if is_connected("thickness") {
         let e = resolved.get("thickness").unwrap();
-        shader.push_str(&format!("    pbr_input.material.thickness = {e};\n"));
+        mutations.push((feeder("thickness"), format!("    pbr_input.material.thickness = {e};")));
     }
     if is_connected("ior") {
         let e = resolved.get("ior").unwrap();
-        shader.push_str(&format!("    pbr_input.material.ior = {e};\n"));
+        mutations.push((feeder("ior"), format!("    pbr_input.material.ior = {e};")));
     }
     if is_connected("attenuation_distance") {
         let e = resolved.get("attenuation_distance").unwrap();
-        shader.push_str(&format!(
-            "    pbr_input.material.attenuation_distance = {e};\n"
-        ));
+        mutations.push((feeder("attenuation_distance"), format!("    pbr_input.material.attenuation_distance = {e};")));
     }
     // The colour light attenuates *toward* over that distance. Without it the
     // distance pin was half a control: thick glass got darker but never took
@@ -3355,13 +3442,11 @@ fn build_pbr_shader(
     // ── Clearcoat (car paint, lacquer) ────────────────────────────────
     if is_connected("clearcoat") {
         let e = resolved.get("clearcoat").unwrap();
-        shader.push_str(&format!("    pbr_input.material.clearcoat = {e};\n"));
+        mutations.push((feeder("clearcoat"), format!("    pbr_input.material.clearcoat = {e};")));
     }
     if is_connected("clearcoat_roughness") {
         let e = resolved.get("clearcoat_roughness").unwrap();
-        shader.push_str(&format!(
-            "    pbr_input.material.clearcoat_perceptual_roughness = {e};\n"
-        ));
+        mutations.push((feeder("clearcoat_roughness"), format!("    pbr_input.material.clearcoat_perceptual_roughness = {e};")));
     }
 
     // ── Anisotropy (brushed metal, hair) ──────────────────────────────
@@ -3369,15 +3454,19 @@ fn build_pbr_shader(
     // takes the rotation angle as a scalar (radians), so we build the vec2.
     if is_connected("anisotropy_strength") {
         let e = resolved.get("anisotropy_strength").unwrap();
-        shader.push_str(&format!(
-            "    pbr_input.material.anisotropy_strength = {e};\n"
-        ));
+        mutations.push((feeder("anisotropy_strength"), format!("    pbr_input.material.anisotropy_strength = {e};")));
     }
     if is_connected("anisotropy_rotation") {
         let e = resolved.get("anisotropy_rotation").unwrap();
-        shader.push_str(&format!(
-            "    pbr_input.material.anisotropy_rotation = vec2<f32>(cos({e}), sin({e}));\n"
-        ));
+        mutations.push((feeder("anisotropy_rotation"), format!("    pbr_input.material.anisotropy_rotation = vec2<f32>(cos({e}), sin({e}));")));
+    }
+
+    let mut extra: Vec<(NodeId, u32, u32)> = Vec::new();
+    for (node, text) in &mutations {
+        let start = shader.matches('\n').count() as u32 + 1;
+        shader.push_str(text);
+        shader.push('\n');
+        extra.push((*node, start, start + text.matches('\n').count() as u32));
     }
 
     // Run alpha_discard before lighting — this is what bevy_pbr::pbr.wgsl
@@ -3395,10 +3484,13 @@ fn build_pbr_shader(
     shader.push_str("    return out;\n");
     shader.push_str("}\n");
 
-    shader
+    (shader, node_line_ranges(ctx, prelude_base, body_base, &extra))
 }
 
-fn build_terrain_layer_shader(ctx: &Ctx, resolved: &HashMap<String, String>) -> String {
+fn build_terrain_layer_shader(
+    ctx: &Ctx,
+    resolved: &HashMap<String, String>,
+) -> (String, Vec<(u64, u32, u32)>) {
     let base_color = resolved
         .get("base_color")
         .cloned()
@@ -3412,6 +3504,7 @@ fn build_terrain_layer_shader(ctx: &Ctx, resolved: &HashMap<String, String>) -> 
     shader.push_str("#import bevy_pbr::mesh_view_bindings::globals\n\n");
     shader.push_str(&texture_bindings_wgsl(ctx));
     shader.push_str(&noise_helpers(ctx));
+    let prelude_base = shader.matches('\n').count() as u32 + 1;
     emit_module_prelude(ctx, &mut shader);
 
     // layer_main: returns base color
@@ -3422,19 +3515,32 @@ fn build_terrain_layer_shader(ctx: &Ctx, resolved: &HashMap<String, String>) -> 
     // Terrain has explicit UV; vertex_color isn't meaningful here so use white.
     shader.push_str("    let mat_uv = uv;\n");
     shader.push_str("    let mat_vertex_color = vec4<f32>(1.0, 1.0, 1.0, 1.0);\n");
+    let body_base = shader.matches('\n').count() as u32 + 1;
     for line in &ctx.lines {
         shader.push_str(line);
         shader.push('\n');
     }
+    let output_id = ctx.graph.output_node().unwrap().id;
+    let feeder = |pin: &str| {
+        ctx.graph
+            .connection_to(output_id, pin)
+            .map(|c| c.from_node)
+            .unwrap_or(output_id)
+    };
+    let mut extra: Vec<(NodeId, u32, u32)> = Vec::new();
+    let start = shader.matches('\n').count() as u32 + 1;
     shader.push_str(&format!("    return {base_color};\n"));
+    extra.push((feeder("base_color"), start, start));
     shader.push_str("}\n\n");
 
     // layer_pbr: returns (metallic, roughness)
     shader.push_str("fn layer_pbr(uv: vec2<f32>, world_pos: vec3<f32>) -> vec2<f32> {\n");
+    let start = shader.matches('\n').count() as u32 + 1;
     shader.push_str(&format!("    return vec2<f32>({metallic}, {roughness});\n"));
+    extra.push((feeder("metallic"), start, start));
     shader.push_str("}\n");
 
-    shader
+    (shader, node_line_ranges(ctx, prelude_base, body_base, &extra))
 }
 
 /// Unlit domain uses the same extension-hook skeleton as Surface. The key
@@ -3442,7 +3548,10 @@ fn build_terrain_layer_shader(ctx: &Ctx, resolved: &HashMap<String, String>) -> 
 /// base — that makes `apply_pbr_lighting` return `base_color` unchanged,
 /// skipping diffuse / specular / IBL. The graph's "color" pin becomes the
 /// material's base_color; "alpha" drives alpha.
-fn build_unlit_shader(ctx: &Ctx, resolved: &HashMap<String, String>) -> String {
+fn build_unlit_shader(
+    ctx: &Ctx,
+    resolved: &HashMap<String, String>,
+) -> (String, Vec<(u64, u32, u32)>) {
     let output_node = ctx.graph.output_node().unwrap();
     let output_id = output_node.id;
     let pin_set = |pin: &str| {
@@ -3456,6 +3565,7 @@ fn build_unlit_shader(ctx: &Ctx, resolved: &HashMap<String, String>) -> String {
     emit_ext_shader_header(ctx, &mut shader);
     shader.push_str(&texture_bindings_wgsl(ctx));
     shader.push_str(&noise_helpers(ctx));
+    let prelude_base = shader.matches('\n').count() as u32 + 1;
     emit_module_prelude(ctx, &mut shader);
 
     shader.push_str("\n@fragment\n");
@@ -3463,6 +3573,7 @@ fn build_unlit_shader(ctx: &Ctx, resolved: &HashMap<String, String>) -> String {
     shader.push_str("    var pbr_input = pbr_input_from_standard_material(in, is_front);\n");
     shader.push_str(&fragment_input_aliases());
 
+    let body_base = shader.matches('\n').count() as u32 + 1;
     for line in &ctx.lines {
         shader.push_str(line);
         shader.push('\n');
@@ -3472,13 +3583,24 @@ fn build_unlit_shader(ctx: &Ctx, resolved: &HashMap<String, String>) -> String {
     // base has `unlit = true`, `apply_pbr_lighting` returns this value
     // unmodified (no lighting math applied) — the fastest path for HUD /
     // debug viz / stylised materials.
+    let feeder = |pin: &str| {
+        ctx.graph
+            .connection_to(output_id, pin)
+            .map(|c| c.from_node)
+            .unwrap_or(output_id)
+    };
+    let mut extra: Vec<(NodeId, u32, u32)> = Vec::new();
     if color_connected {
         let e = resolved.get("color").unwrap();
+        let start = shader.matches('\n').count() as u32 + 1;
         shader.push_str(&format!("    pbr_input.material.base_color = {e};\n"));
+        extra.push((feeder("color"), start, start));
     }
     if alpha_connected {
         let e = resolved.get("alpha").unwrap();
+        let start = shader.matches('\n').count() as u32 + 1;
         shader.push_str(&format!("    pbr_input.material.base_color.a = {e};\n"));
+        extra.push((feeder("alpha"), start, start));
     }
 
     // Match bevy_pbr::pbr.wgsl — alpha_discard handles OPAQUE/MASK before lighting.
@@ -3490,7 +3612,7 @@ fn build_unlit_shader(ctx: &Ctx, resolved: &HashMap<String, String>) -> String {
     shader.push_str("    return out;\n");
     shader.push_str("}\n");
 
-    shader
+    (shader, node_line_ranges(ctx, prelude_base, body_base, &extra))
 }
 
 fn build_vegetation_vertex_shader(_ctx: &Ctx, resolved: &HashMap<String, String>) -> String {
@@ -3786,5 +3908,54 @@ mod tests {
         let shader = compile(&graph).fragment_shader;
         assert!(!shader.contains("calculate_tbn_mikktspace"));
         assert!(!shader.contains("in.world_tangent"));
+    }
+
+    /// 1-based line of the first line containing `needle`.
+    fn line_of(source: &str, needle: &str) -> u32 {
+        source
+            .lines()
+            .position(|l| l.contains(needle))
+            .map(|i| i as u32 + 1)
+            .unwrap_or_else(|| panic!("'{needle}' not in shader:\n{source}"))
+    }
+
+    #[test]
+    fn custom_code_nodes_map_their_lines_back() {
+        let mut graph = MaterialGraph::new("Map", MaterialDomain::Surface);
+        let first = graph.add_node("custom/code", [0.0, 0.0]);
+        graph
+            .get_node_mut(first)
+            .unwrap()
+            .input_values
+            .insert(
+                "code".to_string(),
+                PinValue::String("result = vec4<f32>(1.0, 0.0, 0.0, 1.0);".to_string()),
+            );
+        let second = graph.add_node("custom/code", [100.0, 0.0]);
+        graph
+            .get_node_mut(second)
+            .unwrap()
+            .input_values
+            .insert("code".to_string(), PinValue::String("result = a;".to_string()));
+        let output_id = graph.output_node().unwrap().id;
+        graph.connect(first, "result", second, "a");
+        graph.connect(second, "result", output_id, "base_color");
+
+        let result = compile(&graph);
+        assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+
+        // Two helpers, each starting on its own line — a missing separator
+        // would glue the second `fn` onto the first's closing brace.
+        assert!(result.fragment_shader.contains(&format!("fn mat_custom_{first}(")));
+        assert!(result.fragment_shader.contains(&format!("\nfn mat_custom_{second}(")));
+
+        let first_line = line_of(&result.fragment_shader, "result = vec4<f32>(1.0, 0.0, 0.0, 1.0);");
+        let second_line = line_of(&result.fragment_shader, "result = a;");
+        assert_eq!(node_for_line(&result.node_lines, first_line), Some(first));
+        assert_eq!(node_for_line(&result.node_lines, second_line), Some(second));
+
+        // The PbrInput mutation attributes to the node wired into the pin.
+        let mutation_line = line_of(&result.fragment_shader, "pbr_input.material.base_color = ");
+        assert_eq!(node_for_line(&result.node_lines, mutation_line), Some(second));
     }
 }

--- a/crates/renzora_shader/src/material/graph.rs
+++ b/crates/renzora_shader/src/material/graph.rs
@@ -4,7 +4,7 @@
 //! The editor syncs between this and `NodeGraphState`.
 
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 // ── Identifiers ─────────────────────────────────────────────────────────────
 
@@ -42,6 +42,20 @@ impl PinType {
             // Strings never reach WGSL; this only exists so exhaustiveness
             // holds at the type level.
             Self::String => "f32",
+        }
+    }
+
+    /// Vectorization rank for math-node latching: the widest connected wire
+    /// wins. Color ties with Vec4 — both lower to `vec4<f32>`. Non-numeric
+    /// types rank 0 and never latch anything (they cannot wire into a math
+    /// pin anyway; see [`PinType::compatible`]).
+    pub fn vec_rank(self) -> u8 {
+        match self {
+            Self::Float => 1,
+            Self::Vec2 => 2,
+            Self::Vec3 => 3,
+            Self::Vec4 | Self::Color => 4,
+            _ => 0,
         }
     }
 
@@ -560,5 +574,237 @@ impl MaterialFunction {
             .nodes
             .iter()
             .find(|n| n.node_type == "function/output_point")
+    }
+}
+
+// ── Math-node vectorization ─────────────────────────────────────────────────
+//
+// A math node's pins are not fixed at Float. Attaching a Vec4 wire to
+// `Add.a` latches the whole node — sibling input `b` and output `result`
+// adopt Vec4 — but the node never dictates types to its sources: a narrower
+// wire keeps its own type and `cast_expr` widens it at the destination pin,
+// and a Vec4 *consumer* wired to `result` does not widen the inputs. With no
+// connections a node stays Float, so existing graphs compile byte-identical.
+
+/// Does this pin take part in math-node vectorization?
+///
+/// Every pin of a `math/*` node is dynamic except `math/lerp`'s `t`: WGSL's
+/// `mix` accepts a scalar blend factor alongside vector operands, so `t`
+/// stays Float whatever rank the node adopts.
+pub fn is_dynamic_pin(node_type: &str, pin_name: &str) -> bool {
+    node_type.starts_with("math/") && !(node_type == "math/lerp" && pin_name == "t")
+}
+
+/// Static template lookup for a pin's declared type.
+pub fn static_pin_type(node_type: &str, pin_name: &str, dir: PinDir) -> Option<PinType> {
+    let def = super::nodes::node_def(node_type)?;
+    (def.pins)()
+        .into_iter()
+        .find(|p| p.name == pin_name && p.direction == dir)
+        .map(|p| p.pin_type)
+}
+
+/// Latched type of every `math/*` node in the graph, keyed by node id.
+///
+/// The node's rank is the widest [`PinType::vec_rank`] among its *connected*
+/// dynamic inputs. Rank propagates through chains of math nodes by recursion.
+/// A Vec4/Color tie goes to the earliest pin in template order (strictly
+/// greater replacement), and a connection cycle contributes Float so the walk
+/// always terminates.
+///
+/// The map is a pure function of nodes and connections — nothing is
+/// serialized; a load re-derives it. It is linear in graph size, so there is
+/// no revision cache: codegen computes it once per compile, the editor once
+/// per snapshot pass.
+pub fn resolve_math_ranks(graph: &MaterialGraph) -> HashMap<NodeId, PinType> {
+    let mut ranks = HashMap::new();
+    let mut visiting = HashSet::new();
+    for node in &graph.nodes {
+        if node.node_type.starts_with("math/") {
+            resolve_node_rank(graph, node.id, &mut ranks, &mut visiting);
+        }
+    }
+    ranks
+}
+
+fn resolve_node_rank(
+    graph: &MaterialGraph,
+    id: NodeId,
+    ranks: &mut HashMap<NodeId, PinType>,
+    visiting: &mut HashSet<NodeId>,
+) -> PinType {
+    if let Some(&t) = ranks.get(&id) {
+        return t;
+    }
+    // A cycle offers no widest wire; the revisited node reads as Float so the
+    // recursion bottoms out instead of spinning.
+    if !visiting.insert(id) {
+        return PinType::Float;
+    }
+    let mut best = PinType::Float;
+    if let Some(node) = graph.get_node(id) {
+        if let Some(def) = super::nodes::node_def(&node.node_type) {
+            for pin in (def.pins)() {
+                if pin.direction != PinDir::Input || !is_dynamic_pin(&node.node_type, &pin.name) {
+                    continue;
+                }
+                let Some(conn) = graph.connection_to(id, &pin.name) else {
+                    continue;
+                };
+                let st = source_pin_type(graph, conn, ranks, visiting);
+                if st.vec_rank() > best.vec_rank() {
+                    best = st;
+                }
+            }
+        }
+    }
+    visiting.remove(&id);
+    ranks.insert(id, best);
+    best
+}
+
+/// Resolved type of the pin feeding `conn`: the source math node's own
+/// latched rank when the wire comes from one, the static type otherwise.
+fn source_pin_type(
+    graph: &MaterialGraph,
+    conn: &Connection,
+    ranks: &mut HashMap<NodeId, PinType>,
+    visiting: &mut HashSet<NodeId>,
+) -> PinType {
+    let Some(src) = graph.get_node(conn.from_node) else {
+        return PinType::Float;
+    };
+    if is_dynamic_pin(&src.node_type, &conn.from_pin) {
+        return resolve_node_rank(graph, src.id, ranks, visiting);
+    }
+    static_pin_type(&src.node_type, &conn.from_pin, PinDir::Output).unwrap_or(PinType::Float)
+}
+
+/// The pin type the graph behaves as: the latched rank for a dynamic math
+/// pin, the declared template type for everything else. `ranks` comes from
+/// [`resolve_math_ranks`]; a node missing from it (unconnected) reads Float.
+pub fn resolved_pin_type(
+    ranks: &HashMap<NodeId, PinType>,
+    node: &MaterialNode,
+    pin_name: &str,
+    dir: PinDir,
+) -> Option<PinType> {
+    let declared = static_pin_type(&node.node_type, pin_name, dir)?;
+    if is_dynamic_pin(&node.node_type, pin_name) {
+        return ranks.get(&node.id).copied().or(Some(PinType::Float));
+    }
+    Some(declared)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn graph_with(nodes: &[&str]) -> (MaterialGraph, Vec<NodeId>) {
+        let mut g = MaterialGraph::new("t", MaterialDomain::Surface);
+        let ids = nodes.iter().map(|t| g.add_node(t, [0.0, 0.0])).collect();
+        (g, ids)
+    }
+
+    fn rank(g: &MaterialGraph, id: NodeId) -> PinType {
+        resolve_math_ranks(g).get(&id).copied().unwrap_or(PinType::Float)
+    }
+
+    /// Resolved type of one pin through the full pipeline.
+    fn pin_ty(g: &MaterialGraph, id: NodeId, pin: &str, dir: PinDir) -> PinType {
+        let ranks = resolve_math_ranks(g);
+        resolved_pin_type(&ranks, g.get_node(id).unwrap(), pin, dir).unwrap()
+    }
+
+    #[test]
+    fn unconnected_math_node_stays_float() {
+        let (g, ids) = graph_with(&["math/add"]);
+        assert_eq!(pin_ty(&g, ids[0], "a", PinDir::Input), PinType::Float);
+        assert_eq!(pin_ty(&g, ids[0], "b", PinDir::Input), PinType::Float);
+        assert_eq!(pin_ty(&g, ids[0], "result", PinDir::Output), PinType::Float);
+    }
+
+    #[test]
+    fn vec4_wire_latches_sibling_and_output() {
+        let (mut g, ids) = graph_with(&["math/add", "param/vec4"]);
+        g.connect(ids[1], "value", ids[0], "a");
+        assert_eq!(pin_ty(&g, ids[0], "a", PinDir::Input), PinType::Vec4);
+        assert_eq!(pin_ty(&g, ids[0], "b", PinDir::Input), PinType::Vec4);
+        assert_eq!(pin_ty(&g, ids[0], "result", PinDir::Output), PinType::Vec4);
+    }
+
+    #[test]
+    fn downstream_consumer_does_not_latch() {
+        // A Vec4 sink on `result` must not widen the inputs — latching flows
+        // upstream-to-downstream only.
+        let (mut g, ids) = graph_with(&["math/add"]);
+        let output = g.output_node().unwrap().id;
+        g.connect(ids[0], "result", output, "base_color");
+        assert_eq!(rank(&g, ids[0]), PinType::Float);
+    }
+
+    #[test]
+    fn widest_wire_wins_and_detach_recomputes() {
+        let (mut g, ids) = graph_with(&["math/add", "param/vec2", "param/vec4"]);
+        g.connect(ids[1], "value", ids[0], "a");
+        g.connect(ids[2], "value", ids[0], "b");
+        assert_eq!(rank(&g, ids[0]), PinType::Vec4);
+        g.disconnect(ids[0], "b");
+        assert_eq!(rank(&g, ids[0]), PinType::Vec2);
+        g.disconnect(ids[0], "a");
+        assert_eq!(rank(&g, ids[0]), PinType::Float);
+    }
+
+    #[test]
+    fn scalar_wire_never_latches() {
+        let (mut g, ids) = graph_with(&["math/multiply", "param/float"]);
+        g.connect(ids[1], "value", ids[0], "a");
+        assert_eq!(rank(&g, ids[0]), PinType::Float);
+    }
+
+    #[test]
+    fn rank_propagates_through_math_chains() {
+        let (mut g, ids) = graph_with(&["math/add", "math/multiply", "param/vec3"]);
+        g.connect(ids[2], "value", ids[0], "a");
+        g.connect(ids[0], "result", ids[1], "a");
+        assert_eq!(rank(&g, ids[0]), PinType::Vec3);
+        assert_eq!(rank(&g, ids[1]), PinType::Vec3);
+        assert_eq!(pin_ty(&g, ids[1], "result", PinDir::Output), PinType::Vec3);
+    }
+
+    #[test]
+    fn connection_cycle_terminates_as_float() {
+        let (mut g, ids) = graph_with(&["math/add", "math/add"]);
+        g.connect(ids[0], "result", ids[1], "a");
+        g.connect(ids[1], "result", ids[0], "a");
+        assert_eq!(rank(&g, ids[0]), PinType::Float);
+        assert_eq!(rank(&g, ids[1]), PinType::Float);
+    }
+
+    #[test]
+    fn lerp_t_stays_float_when_node_latches() {
+        let (mut g, ids) = graph_with(&["math/lerp", "param/vec4"]);
+        g.connect(ids[1], "value", ids[0], "a");
+        assert_eq!(pin_ty(&g, ids[0], "result", PinDir::Output), PinType::Vec4);
+        assert_eq!(pin_ty(&g, ids[0], "t", PinDir::Input), PinType::Float);
+    }
+
+    #[test]
+    fn vec4_color_tie_goes_to_first_pin() {
+        // Both rank 4; strictly-greater replacement keeps the earliest pin's
+        // type, so the latch is deterministic.
+        let (mut g, ids) = graph_with(&["math/add", "param/color", "param/vec4"]);
+        g.connect(ids[1], "value", ids[0], "a");
+        g.connect(ids[2], "value", ids[0], "b");
+        assert_eq!(rank(&g, ids[0]), PinType::Color);
+    }
+
+    #[test]
+    fn saved_graph_re_derives_identical_ranks() {
+        let (mut g, ids) = graph_with(&["math/add", "param/vec3"]);
+        g.connect(ids[1], "value", ids[0], "a");
+        let json = serde_json::to_string(&g).unwrap();
+        let loaded: MaterialGraph = serde_json::from_str(&json).unwrap();
+        assert_eq!(resolve_math_ranks(&g), resolve_math_ranks(&loaded));
     }
 }

--- a/crates/renzora_shader/src/material/graph.rs
+++ b/crates/renzora_shader/src/material/graph.rs
@@ -99,6 +99,10 @@ impl PinType {
             (PinType::Vec4, PinType::Vec2) => format!("({e}).xy"),
             (PinType::Vec4, PinType::Vec3) => format!("({e}).xyz"),
 
+            // `param/bool` emits a real WGSL `bool`. The fallthrough below
+            // hands it to a float pin unchanged, and naga rejects it.
+            (PinType::Bool, PinType::Float) => format!("select(0.0, 1.0, {e})"),
+
             _ => expr.to_string(),
         }
     }
@@ -153,7 +157,9 @@ impl PinValue {
             // Guard against non-finite values reaching the shader — `{:.6}` on
             // inf/NaN emits `inf`/`NaN`, which is not valid WGSL and would fail
             // pipeline creation for the whole material.
-            Self::Float(v) => format!("{:.6}", if v.is_finite() { *v } else { 0.0 }),
+            // `f32(..)`, not a bare literal: naga will not concretize a builtin
+            // call whose every argument is abstract, for example an unwired `math/lerp`.
+            Self::Float(v) => format!("f32({:.6})", if v.is_finite() { *v } else { 0.0 }),
             Self::Vec2([x, y]) => format!("vec2<f32>({:.6}, {:.6})", x, y),
             Self::Vec3([x, y, z]) => format!("vec3<f32>({:.6}, {:.6}, {:.6})", x, y, z),
             Self::Vec4([x, y, z, w]) | Self::Color([x, y, z, w]) => {

--- a/crates/renzora_shader/src/material/mod.rs
+++ b/crates/renzora_shader/src/material/mod.rs
@@ -11,6 +11,10 @@ pub mod runtime;
 pub mod standard_build;
 pub mod surface_ext;
 pub mod texture_slots;
+// Problems-panel validation: a naga_oil composer over all of bevy_pbr's
+// modules plus a naga pass per material. A shipped game has no Problems
+// panel, so it never pays for this.
+#[cfg(feature = "editor")]
 pub mod validate;
 
 // Re-export the public asset type at module root so downstream code can write

--- a/crates/renzora_shader/src/material/mod.rs
+++ b/crates/renzora_shader/src/material/mod.rs
@@ -11,6 +11,7 @@ pub mod runtime;
 pub mod standard_build;
 pub mod surface_ext;
 pub mod texture_slots;
+pub mod validate;
 
 // Re-export the public asset type at module root so downstream code can write
 // `material::GraphMaterial` the same way it did before this rewrite.
@@ -99,9 +100,12 @@ fn on_pbr_material_extracted(trigger: On<renzora::PbrMaterialExtracted>) {
 
     let mut graph = pbr_build::pbr_to_graph(&inputs);
     match precompiled::save_compiled_and_serialize(&mut graph, &path) {
-        Ok((json, errors)) => {
-            for err in &errors {
+        Ok((json, report)) => {
+            for err in &report.errors {
                 warn!("[material] codegen '{}': {}", ev.name, err);
+            }
+            for warning in &report.warnings {
+                warn!("[material] codegen warning '{}': {}", ev.name, warning);
             }
             if let Err(e) = std::fs::write(&path, json) {
                 warn!("[material] write '{}': {}", path.display(), e);

--- a/crates/renzora_shader/src/material/precompiled.rs
+++ b/crates/renzora_shader/src/material/precompiled.rs
@@ -54,6 +54,11 @@ pub struct CompiledMaterialMeta {
     pub requires_transmission: bool,
     pub texture_bindings: Vec<TextureBinding>,
     pub parameters: Vec<MaterialParam>,
+    /// `(node id, first line, last line)` — which graph node authored which
+    /// lines of the shader, so a compile error can point at a node. Empty
+    /// for artifacts written before this field existed.
+    #[serde(default)]
+    pub node_line_map: Vec<(u64, u32, u32)>,
 }
 
 /// Filesystem path of the legacy `.wgsl` for a `.material` at
@@ -130,6 +135,7 @@ pub fn save_compiled(
             requires_transmission: result.requires_transmission,
             texture_bindings: result.texture_bindings,
             parameters: result.parameters,
+            node_line_map: result.node_lines,
         },
     });
     graph.wgsl_path = None;

--- a/crates/renzora_shader/src/material/precompiled.rs
+++ b/crates/renzora_shader/src/material/precompiled.rs
@@ -85,11 +85,19 @@ pub fn project_relative(project_root: &Path, fs_path: &Path) -> String {
         .unwrap_or_else(|_| fs_path.to_string_lossy().replace('\\', "/"))
 }
 
+/// What a save-compile has to say. `errors` non-empty means no artifact was
+/// embedded. `warnings` means one was, but the graph is on borrowed time.
+#[derive(Debug, Default)]
+pub struct SaveReport {
+    pub errors: Vec<String>,
+    pub warnings: Vec<String>,
+}
+
 /// Run codegen on `graph` and store the result in [`MaterialGraph::compiled`]
 /// so a subsequent `serde_json::to_string_pretty(&graph)` in the caller writes
 /// the shader into the `.material` file itself.
 ///
-/// Returns the codegen errors. An empty `Vec` means the artifact was embedded
+/// Returns the [`SaveReport`]. Empty `errors` means the artifact was embedded
 /// successfully. On codegen error the artifact is cleared, so the resolver
 /// falls back to live codegen rather than rendering a stale shader.
 ///
@@ -102,12 +110,15 @@ pub fn project_relative(project_root: &Path, fs_path: &Path) -> String {
 pub fn save_compiled(
     graph: &mut MaterialGraph,
     material_fs_path: &Path,
-) -> io::Result<Vec<String>> {
+) -> io::Result<SaveReport> {
     let result = codegen::compile_with_functions(graph, None);
     if !result.errors.is_empty() {
         graph.compiled = None;
         graph.wgsl_path = None;
-        return Ok(result.errors);
+        return Ok(SaveReport {
+            errors: result.errors,
+            warnings: result.warnings,
+        });
     }
 
     graph.compiled = Some(CompiledArtifact {
@@ -123,7 +134,10 @@ pub fn save_compiled(
     });
     graph.wgsl_path = None;
     remove_legacy_artifacts(material_fs_path);
-    Ok(Vec::new())
+    Ok(SaveReport {
+        errors: Vec::new(),
+        warnings: result.warnings,
+    })
 }
 
 /// Delete the `.wgsl` + `.wgsl.meta` pair the three-file layout wrote next to
@@ -156,10 +170,10 @@ fn remove_legacy_artifacts(material_fs_path: &Path) {
 pub fn save_compiled_and_serialize(
     graph: &mut MaterialGraph,
     material_fs_path: &Path,
-) -> io::Result<(String, Vec<String>)> {
-    let errors = save_compiled(graph, material_fs_path)?;
+) -> io::Result<(String, SaveReport)> {
+    let report = save_compiled(graph, material_fs_path)?;
     let json = serde_json::to_string_pretty(graph).map_err(io::Error::other)?;
-    Ok((json, errors))
+    Ok((json, report))
 }
 
 #[cfg(test)]
@@ -174,10 +188,10 @@ mod tests {
     #[test]
     fn compiled_artifact_survives_a_save_load_round_trip() {
         let mut graph = MaterialGraph::new("RoundTrip", MaterialDomain::Surface);
-        let (json, errors) =
+        let (json, report) =
             save_compiled_and_serialize(&mut graph, Path::new("materials/round_trip.material"))
                 .expect("save");
-        assert!(errors.is_empty(), "codegen errors: {errors:?}");
+        assert!(report.errors.is_empty(), "codegen errors: {:?}", report.errors);
 
         let reloaded: MaterialGraph = serde_json::from_str(&json).expect("parse");
         let artifact = reloaded.compiled.as_ref().expect("artifact embedded");

--- a/crates/renzora_shader/src/material/resolver.rs
+++ b/crates/renzora_shader/src/material/resolver.rs
@@ -226,11 +226,12 @@ fn report_material_problems(
         };
         let node_lines = cache.node_line_maps.get(path).map(Vec::as_slice).unwrap_or(&[]);
         let found = validator.problems_for_source(&source, node_lines);
-        // Logged as well as recorded: the uuid key means this runs once per
-        // compile, so the console gets the errors without repeating them every
-        // frame, and `runtime_warnings` picks them up for Scene Diagnostics.
+        // Logged to both consoles, once per compile (the uuid key): `warn!`
+        // feeds Scene Diagnostics via `runtime_warnings`, `console_error`
+        // feeds the Console panel's buffer.
         for problem in &found {
             warn!("{}: {}", path, problem.message);
+            renzora::console_log::console_error("Material", format!("{path}: {}", problem.message));
         }
         // Errors only — the compile sites own the Warning rows for this path.
         problems.set_severity(
@@ -473,6 +474,7 @@ fn resolve_material_refs(
                         is_derived, fs_path
                     );
                     warn!("Failed to resolve material file: {} ({})", path, err);
+                    renzora::console_log::console_error("Material", format!("Failed to resolve {path}: {err}"));
                     problems.set(
                         path.clone(),
                         vec![renzora::content_problems::ContentProblem {
@@ -1098,11 +1100,13 @@ fn resolve_graph_material_from_graph(
     if !result.errors.is_empty() {
         for err in &result.errors {
             error!("Material compile error in '{}': {}", path, err);
+            renzora::console_log::console_error("Material", format!("{path}: {err}"));
         }
         return None;
     }
     for warning in &result.warnings {
         warn!("Material compile warning in '{}': {}", path, warning);
+        renzora::console_log::console_warn("Material", format!("{path}: {warning}"));
     }
 
     let (handle, parameters) = assemble_graph_material(

--- a/crates/renzora_shader/src/material/resolver.rs
+++ b/crates/renzora_shader/src/material/resolver.rs
@@ -75,6 +75,12 @@ pub struct MaterialCache {
     /// override map and to copy the master's authored defaults into the
     /// instance's parameter buffer. Keyed by master `.material` path.
     master_meta: HashMap<String, MasterMeta>,
+    /// `(node, first line, last line)` source maps from codegen, keyed by
+    /// `.material` path. What lets `report_material_problems` put a compile
+    /// error on a graph node. Sits here rather than in `MasterMeta` because
+    /// the precompiled path reads it from the saved `.material`, not from
+    /// a compile.
+    node_line_maps: HashMap<String, Vec<(u64, u32, u32)>>,
     /// Tracks which paths have been loaded (for future hot-reload).
     #[allow(dead_code)]
     loaded_paths: HashMap<String, u64>,
@@ -96,6 +102,7 @@ impl MaterialCache {
         self.graph_materials.remove(path);
         self.code_materials.remove(path);
         self.master_meta.remove(path);
+        self.node_line_maps.remove(path);
         self.loaded_paths.remove(path);
     }
 
@@ -145,6 +152,11 @@ enum CompiledMaterial {
         /// itself — the precompiled path compiles at save time, where the
         /// save site owns the warning, so `None` means "not ours to report".
         warnings: Option<Vec<String>>,
+        /// `(node, first line, last line)` — the source map compile errors
+        /// are attributed through. From codegen on the live path, from the
+        /// embedded artifact's meta (or the legacy `.wgsl.meta` sidecar) on
+        /// the precompiled one.
+        node_lines: Vec<(u64, u32, u32)>,
     },
 }
 
@@ -212,7 +224,8 @@ fn report_material_problems(
         else {
             continue;
         };
-        let found = validator.problems_for_source(&source);
+        let node_lines = cache.node_line_maps.get(path).map(Vec::as_slice).unwrap_or(&[]);
+        let found = validator.problems_for_source(&source, node_lines);
         // Logged as well as recorded: the uuid key means this runs once per
         // compile, so the console gets the errors without repeating them every
         // frame, and `runtime_warnings` picks them up for Scene Diagnostics.
@@ -414,7 +427,7 @@ fn resolve_material_refs(
                     ));
                     perf.record_compile_success(path, MaterialKind::Standard, compile_dur);
                 }
-                Some(CompiledMaterial::Graph { handle, parameters, warnings }) => {
+                Some(CompiledMaterial::Graph { handle, parameters, warnings, node_lines }) => {
                     cache.graph_materials.insert(path.clone(), handle.clone());
                     // This resolve ran the codegen, so it owns the path's
                     // Warning rows. `None` (precompiled, instance) leaves
@@ -429,6 +442,7 @@ fn resolve_material_refs(
                                     severity: renzora::content_problems::ProblemSeverity::Warning,
                                     message: w.clone(),
                                     line: None,
+                                    node_id: None,
                                 })
                                 .collect(),
                         );
@@ -440,6 +454,7 @@ fn resolve_material_refs(
                         cache
                             .master_meta
                             .insert(path.clone(), MasterMeta { parameters });
+                        cache.node_line_maps.insert(path.clone(), node_lines);
                     }
                     commands
                         .entity(entity)
@@ -464,6 +479,7 @@ fn resolve_material_refs(
                             severity: renzora::content_problems::ProblemSeverity::Error,
                             message: err.clone(),
                             line: None,
+                            node_id: None,
                         }],
                     );
                     commands.entity(entity).try_insert(MaterialResolved {
@@ -750,6 +766,7 @@ fn resolve_material_file(
     // Everything the renderer needs is right here, so codegen never runs.
     if let Some(compiled) = graph.compiled.as_ref() {
         let meta = &compiled.meta;
+        let node_lines = meta.node_line_map.clone();
         let (handle, parameters) = assemble_graph_material(
             path,
             compiled.wgsl.clone(),
@@ -765,7 +782,7 @@ fn resolve_material_file(
             fallback_texture,
             asset_server,
         );
-        return Some(CompiledMaterial::Graph { handle, parameters, warnings: None });
+        return Some(CompiledMaterial::Graph { handle, parameters, warnings: None, node_lines });
     }
 
     // Legacy three-file layout: the shader lives in a `.wgsl` beside this
@@ -773,6 +790,7 @@ fn resolve_material_file(
     // artifact was embedded land here until their next save.
     if let Some(wgsl_path) = graph.wgsl_path.as_deref() {
         if let Some((wgsl, meta)) = load_compiled_from_vfs(wgsl_path, project, reader) {
+            let node_lines = meta.node_line_map.clone();
             let (handle, parameters) = assemble_graph_material(
                 wgsl_path,
                 wgsl,
@@ -790,7 +808,7 @@ fn resolve_material_file(
                 fallback_texture,
                 asset_server,
             );
-            return Some(CompiledMaterial::Graph { handle, parameters, warnings: None });
+            return Some(CompiledMaterial::Graph { handle, parameters, warnings: None, node_lines });
         }
         warn!(
             "Material '{}' references missing or unreadable wgsl '{}'; falling back to live codegen",
@@ -801,7 +819,7 @@ fn resolve_material_file(
     // Nothing compiled to load — a graph that has never been saved, or one
     // whose last compile failed. Run the full graph→WGSL codegen now so it
     // still renders while the user is working on it.
-    let (handle, parameters, warnings) = resolve_graph_material_from_graph(
+    let (handle, parameters, warnings, node_lines) = resolve_graph_material_from_graph(
         path,
         &graph,
         graph_materials,
@@ -810,7 +828,7 @@ fn resolve_material_file(
         fallback_texture,
         asset_server,
     )?;
-    Some(CompiledMaterial::Graph { handle, parameters, warnings: Some(warnings) })
+    Some(CompiledMaterial::Graph { handle, parameters, warnings: Some(warnings), node_lines })
 }
 
 /// Read a `.wgsl` plus its `.wgsl.meta` sidecar via the project VFS. Both
@@ -978,8 +996,9 @@ fn resolve_material_instance_file(
                 load_compiled_from_vfs(wp, project, reader).map(|loaded| (wp.to_string(), loaded))
             }),
         };
-        let (handle, parameters) = if let Some((wgsl_key, (wgsl, meta))) = from_precompiled {
-            assemble_graph_material(
+        let (handle, parameters, node_lines) = if let Some((wgsl_key, (wgsl, meta))) = from_precompiled {
+            let node_lines = meta.node_line_map.clone();
+            let (handle, parameters) = assemble_graph_material(
                 &wgsl_key,
                 wgsl,
                 meta.domain,
@@ -993,11 +1012,12 @@ fn resolve_material_instance_file(
                 shaders,
                 fallback_texture,
                 asset_server,
-            )
+            );
+            (handle, parameters, node_lines)
         } else {
             // Warnings drop here: the console already has them, and the panel
             // hears them under the master's own path when it resolves.
-            let (handle, parameters, _) = resolve_graph_material_from_graph(
+            let (handle, parameters, _, node_lines) = resolve_graph_material_from_graph(
                 &master_fs_path,
                 &master_graph,
                 graph_materials,
@@ -1006,12 +1026,13 @@ fn resolve_material_instance_file(
                 fallback_texture,
                 asset_server,
             )?;
-            (handle, parameters)
+            (handle, parameters, node_lines)
         };
         cache.graph_materials.insert(master_key.clone(), handle);
         cache
             .master_meta
             .insert(master_key.clone(), MasterMeta { parameters });
+        cache.node_line_maps.insert(master_key.clone(), node_lines);
     }
 
     // 2. Pull the master GraphMaterial out of the asset store. We can't
@@ -1039,6 +1060,7 @@ fn resolve_material_instance_file(
         // doesn't accidentally insert a stale entry under the instance path.
         parameters: Vec::new(),
         warnings: None,
+        node_lines: Vec::new(),
     })
 }
 
@@ -1061,7 +1083,7 @@ fn resolve_graph_material_from_graph(
     _shader_state: &mut GraphMaterialShaderState,
     fallback_texture: &Option<Res<FallbackTexture>>,
     asset_server: &AssetServer,
-) -> Option<(Handle<GraphMaterial>, Vec<MaterialParam>, Vec<String>)> {
+) -> Option<(Handle<GraphMaterial>, Vec<MaterialParam>, Vec<String>, Vec<(u64, u32, u32)>)> {
     // Load any sibling `.material_function` files in the same directory so the
     // graph can reference them via function/call nodes.
     let functions = load_sibling_functions(path);
@@ -1098,7 +1120,7 @@ fn resolve_graph_material_from_graph(
         fallback_texture,
         asset_server,
     );
-    Some((handle, parameters, result.warnings))
+    Some((handle, parameters, result.warnings, result.node_lines))
 }
 
 /// Build the `GraphMaterial` asset from already-compiled WGSL plus the

--- a/crates/renzora_shader/src/material/resolver.rs
+++ b/crates/renzora_shader/src/material/resolver.rs
@@ -177,6 +177,22 @@ impl Plugin for MaterialResolverPlugin {
         // Problems-panel validation: re-composes every graph material's WGSL
         // against all of bevy_pbr's modules and naga-validates it on the main
         // thread. Editor-only — a shipped game has no Problems panel.
+        //
+        // Gated TWICE, because neither gate alone is enough:
+        //
+        //   * The `editor` feature keeps `validate.rs` and its `naga_oil`
+        //     dependency out of a build that resolves only runtime crates.
+        //     That is a binary-size win, and it is ALL it is: `xtask` builds
+        //     with one `cargo build --workspace`, so cargo unifies features
+        //     across both executables and `renzora_material_editor`'s opt-in
+        //     turns this feature on for the runtime binary too. Confirm with
+        //     `cargo tree -p renzora_app -p renzora_editor_app -i
+        //     renzora_shader -e features` — `editor` is active there, and
+        //     absent from `-p renzora_app` alone.
+        //   * So correctness rides on `EditorSession`, decided at runtime from
+        //     whether the editor bundle is present. Same signal the rest of
+        //     the engine branches on, and the only one a shipped game cannot
+        //     accidentally satisfy.
         #[cfg(feature = "editor")]
         app
             // `PreUpdate`: the validator arrives via `Commands`, and a material
@@ -186,10 +202,26 @@ impl Plugin for MaterialResolverPlugin {
             // stream in while the asset set is actually changing.
             .add_systems(
                 PreUpdate,
-                ensure_shader_validator.run_if(resource_changed::<Assets<Shader>>),
+                ensure_shader_validator
+                    .run_if(resource_changed::<Assets<Shader>>)
+                    .run_if(in_editor_session),
             )
-            .add_systems(Update, report_material_problems.after(resolve_material_refs));
+            .add_systems(
+                Update,
+                report_material_problems
+                    .after(resolve_material_refs)
+                    .run_if(in_editor_session),
+            );
     }
+}
+
+/// Whether this process is an editor session rather than a shipped game.
+///
+/// Absent resource reads as "game": `EditorSession` is inserted during runtime
+/// setup, so a system scheduled before it lands must not assume editor.
+#[cfg(feature = "editor")]
+fn in_editor_session(session: Option<Res<renzora::EditorSession>>) -> bool {
+    session.is_some_and(|s| s.is_editor())
 }
 
 /// Compile the WGSL each graph material binds and record what the compiler says.

--- a/crates/renzora_shader/src/material/resolver.rs
+++ b/crates/renzora_shader/src/material/resolver.rs
@@ -141,6 +141,10 @@ enum CompiledMaterial {
     Graph {
         handle: Handle<GraphMaterial>,
         parameters: Vec<MaterialParam>,
+        /// Codegen warnings. `Some` only when this resolve ran the codegen
+        /// itself — the precompiled path compiles at save time, where the
+        /// save site owns the warning, so `None` means "not ours to report".
+        warnings: Option<Vec<String>>,
     },
 }
 
@@ -153,11 +157,96 @@ impl Plugin for MaterialResolverPlugin {
         app.init_resource::<MaterialCache>()
             .init_resource::<super::perf::MaterialPerfStats>()
             .init_resource::<renzora::VirtualFileReader>()
+            .init_resource::<renzora::content_problems::ContentProblems>()
             .register_type::<MaterialRef>()
             .register_type::<super::material_ref::MaterialOverrides>()
             .register_type::<super::material_ref::ParamValue>()
-            .add_systems(Update, resolve_material_refs);
+            // `PreUpdate`: the validator arrives via `Commands`, and a material
+            // resolved the same frame reports nothing, then is never looked at
+            // again.
+            .add_systems(PreUpdate, ensure_shader_validator)
+            .add_systems(Update, (resolve_material_refs, report_material_problems).chain());
     }
+}
+
+/// Compile the WGSL each graph material binds and record what the compiler says.
+///
+/// Keyed on the shader uuid rather than driven off the resolve, because the
+/// validator needs bevy_pbr's libraries and those land a frame after the first
+/// material resolves. A fresh uuid per compile catches recompiles too.
+fn report_material_problems(
+    mut checked: Local<HashMap<String, (Uuid, usize)>>,
+    cache: Res<MaterialCache>,
+    graph_materials: Option<Res<Assets<GraphMaterial>>>,
+    shaders: Option<Res<Assets<Shader>>>,
+    validator: Option<ResMut<super::validate::ShaderValidator>>,
+    mut problems: ResMut<renzora::content_problems::ContentProblems>,
+) {
+    let (Some(mut validator), Some(graph_materials), Some(shaders)) =
+        (validator, graph_materials, shaders)
+    else {
+        return;
+    };
+    let libraries = validator.library_count();
+
+    checked.retain(|path, _| cache.graph_materials.contains_key(path));
+    for (path, handle) in &cache.graph_materials {
+        let Some(uuid) = graph_materials
+            .get(handle)
+            .and_then(|m| m.extension.shader_uuid)
+        else {
+            continue;
+        };
+        // The library count is part of the key: a verdict reached against a
+        // validator that had fewer libraries was reached against imports that
+        // had not arrived yet, and has to be taken again.
+        if checked.get(path) == Some(&(uuid, libraries)) {
+            continue;
+        }
+        let Some(source) = shaders
+            .get(&Handle::<Shader>::Uuid(uuid, PhantomData))
+            .and_then(|shader| match &shader.source {
+                bevy::shader::Source::Wgsl(src) => Some(src.to_string()),
+                _ => None,
+            })
+        else {
+            continue;
+        };
+        let found = validator.problems_for_source(&source);
+        // Logged as well as recorded: the uuid key means this runs once per
+        // compile, so the console gets the errors without repeating them every
+        // frame, and `runtime_warnings` picks them up for Scene Diagnostics.
+        for problem in &found {
+            warn!("{}: {}", path, problem.message);
+        }
+        // Errors only — the compile sites own the Warning rows for this path.
+        problems.set_severity(
+            path.clone(),
+            renzora::content_problems::ProblemSeverity::Error,
+            found,
+        );
+        checked.insert(path.clone(), (uuid, libraries));
+    }
+}
+
+/// Build the validator once the shader libraries have loaded, and rebuild it
+/// whenever their number changes.
+///
+/// Not at plugin-build time: bevy_pbr's libraries are embedded assets and only
+/// land in `Assets<Shader>` over the frames that follow, so a validator built
+/// on the first one that appears is missing most of the imports a material
+/// needs.
+fn ensure_shader_validator(
+    mut commands: Commands,
+    existing: Option<Res<super::validate::ShaderValidator>>,
+    shaders: Option<Res<Assets<Shader>>>,
+) {
+    let Some(shaders) = shaders else { return };
+    let count = super::validate::library_count(&shaders);
+    if count == 0 || existing.map(|v| v.library_count()) == Some(count) {
+        return;
+    }
+    commands.insert_resource(super::validate::ShaderValidator::new(&shaders));
 }
 
 /// System that finds entities with `MaterialRef` + `Mesh3d` that don't yet have a resolved material,
@@ -168,6 +257,7 @@ fn resolve_material_refs(
     query: Query<(Entity, &MaterialRef), Without<MaterialResolved>>,
     mut cache: ResMut<MaterialCache>,
     mut perf: ResMut<super::perf::MaterialPerfStats>,
+    mut problems: ResMut<renzora::content_problems::ContentProblems>,
     standard_materials: Option<ResMut<Assets<bevy::pbr::StandardMaterial>>>,
     graph_materials: Option<ResMut<Assets<GraphMaterial>>>,
     code_materials: Option<ResMut<Assets<CodeShaderMaterial>>>,
@@ -307,6 +397,9 @@ fn resolve_material_refs(
             let compile_dur = start.elapsed();
             match result {
                 Some(CompiledMaterial::Standard(handle)) => {
+                    // A trivial material is a plain `StandardMaterial` on Bevy's
+                    // own pipeline — no generated WGSL, so nothing to be wrong.
+                    problems.clear_path(path);
                     cache
                         .standard_materials
                         .insert(path.clone(), handle.clone());
@@ -321,8 +414,25 @@ fn resolve_material_refs(
                     ));
                     perf.record_compile_success(path, MaterialKind::Standard, compile_dur);
                 }
-                Some(CompiledMaterial::Graph { handle, parameters }) => {
+                Some(CompiledMaterial::Graph { handle, parameters, warnings }) => {
                     cache.graph_materials.insert(path.clone(), handle.clone());
+                    // This resolve ran the codegen, so it owns the path's
+                    // Warning rows. `None` (precompiled, instance) leaves
+                    // them to whoever compiled the shader.
+                    if let Some(warnings) = warnings {
+                        problems.set_severity(
+                            path.clone(),
+                            renzora::content_problems::ProblemSeverity::Warning,
+                            warnings
+                                .iter()
+                                .map(|w| renzora::content_problems::ContentProblem {
+                                    severity: renzora::content_problems::ProblemSeverity::Warning,
+                                    message: w.clone(),
+                                    line: None,
+                                })
+                                .collect(),
+                        );
+                    }
                     // Master-meta only applies to non-derived files —
                     // derived files inherit their master's parameter
                     // list, which we don't re-cache here.
@@ -348,6 +458,14 @@ fn resolve_material_refs(
                         is_derived, fs_path
                     );
                     warn!("Failed to resolve material file: {} ({})", path, err);
+                    problems.set(
+                        path.clone(),
+                        vec![renzora::content_problems::ContentProblem {
+                            severity: renzora::content_problems::ProblemSeverity::Error,
+                            message: err.clone(),
+                            line: None,
+                        }],
+                    );
                     commands.entity(entity).try_insert(MaterialResolved {
                         source_path: path.clone(),
                     });
@@ -647,7 +765,7 @@ fn resolve_material_file(
             fallback_texture,
             asset_server,
         );
-        return Some(CompiledMaterial::Graph { handle, parameters });
+        return Some(CompiledMaterial::Graph { handle, parameters, warnings: None });
     }
 
     // Legacy three-file layout: the shader lives in a `.wgsl` beside this
@@ -672,7 +790,7 @@ fn resolve_material_file(
                 fallback_texture,
                 asset_server,
             );
-            return Some(CompiledMaterial::Graph { handle, parameters });
+            return Some(CompiledMaterial::Graph { handle, parameters, warnings: None });
         }
         warn!(
             "Material '{}' references missing or unreadable wgsl '{}'; falling back to live codegen",
@@ -683,7 +801,7 @@ fn resolve_material_file(
     // Nothing compiled to load — a graph that has never been saved, or one
     // whose last compile failed. Run the full graph→WGSL codegen now so it
     // still renders while the user is working on it.
-    let (handle, parameters) = resolve_graph_material_from_graph(
+    let (handle, parameters, warnings) = resolve_graph_material_from_graph(
         path,
         &graph,
         graph_materials,
@@ -692,7 +810,7 @@ fn resolve_material_file(
         fallback_texture,
         asset_server,
     )?;
-    Some(CompiledMaterial::Graph { handle, parameters })
+    Some(CompiledMaterial::Graph { handle, parameters, warnings: Some(warnings) })
 }
 
 /// Read a `.wgsl` plus its `.wgsl.meta` sidecar via the project VFS. Both
@@ -877,7 +995,9 @@ fn resolve_material_instance_file(
                 asset_server,
             )
         } else {
-            resolve_graph_material_from_graph(
+            // Warnings drop here: the console already has them, and the panel
+            // hears them under the master's own path when it resolves.
+            let (handle, parameters, _) = resolve_graph_material_from_graph(
                 &master_fs_path,
                 &master_graph,
                 graph_materials,
@@ -885,7 +1005,8 @@ fn resolve_material_instance_file(
                 shader_state,
                 fallback_texture,
                 asset_server,
-            )?
+            )?;
+            (handle, parameters)
         };
         cache.graph_materials.insert(master_key.clone(), handle);
         cache
@@ -917,14 +1038,15 @@ fn resolve_material_instance_file(
         // master's parameter list. Returning empty so the dispatch site
         // doesn't accidentally insert a stale entry under the instance path.
         parameters: Vec::new(),
+        warnings: None,
     })
 }
 
 /// Compile an already-parsed [`MaterialGraph`] into a procedural
 /// [`GraphMaterial`] (`ExtendedMaterial<StandardMaterial, SurfaceGraphExt>`).
 ///
-/// Returns the asset handle paired with the parameter list the codegen
-/// discovered. The latter is what callers need to cache in `MasterMeta` so
+/// Returns the asset handle, the parameter list the codegen discovered, and
+/// its warnings. The parameter list is what callers cache in `MasterMeta` so
 /// material instances of this master can write into the right uniform slots.
 ///
 /// This is the path for graphs containing procedural / math / animation /
@@ -939,7 +1061,7 @@ fn resolve_graph_material_from_graph(
     _shader_state: &mut GraphMaterialShaderState,
     fallback_texture: &Option<Res<FallbackTexture>>,
     asset_server: &AssetServer,
-) -> Option<(Handle<GraphMaterial>, Vec<MaterialParam>)> {
+) -> Option<(Handle<GraphMaterial>, Vec<MaterialParam>, Vec<String>)> {
     // Load any sibling `.material_function` files in the same directory so the
     // graph can reference them via function/call nodes.
     let functions = load_sibling_functions(path);
@@ -957,8 +1079,11 @@ fn resolve_graph_material_from_graph(
         }
         return None;
     }
+    for warning in &result.warnings {
+        warn!("Material compile warning in '{}': {}", path, warning);
+    }
 
-    Some(assemble_graph_material(
+    let (handle, parameters) = assemble_graph_material(
         path,
         result.fragment_shader,
         result.domain,
@@ -972,7 +1097,8 @@ fn resolve_graph_material_from_graph(
         shaders,
         fallback_texture,
         asset_server,
-    ))
+    );
+    Some((handle, parameters, result.warnings))
 }
 
 /// Build the `GraphMaterial` asset from already-compiled WGSL plus the

--- a/crates/renzora_shader/src/material/resolver.rs
+++ b/crates/renzora_shader/src/material/resolver.rs
@@ -173,11 +173,22 @@ impl Plugin for MaterialResolverPlugin {
             .register_type::<MaterialRef>()
             .register_type::<super::material_ref::MaterialOverrides>()
             .register_type::<super::material_ref::ParamValue>()
+            .add_systems(Update, resolve_material_refs);
+        // Problems-panel validation: re-composes every graph material's WGSL
+        // against all of bevy_pbr's modules and naga-validates it on the main
+        // thread. Editor-only — a shipped game has no Problems panel.
+        #[cfg(feature = "editor")]
+        app
             // `PreUpdate`: the validator arrives via `Commands`, and a material
             // resolved the same frame reports nothing, then is never looked at
-            // again.
-            .add_systems(PreUpdate, ensure_shader_validator)
-            .add_systems(Update, (resolve_material_refs, report_material_problems).chain());
+            // again. `resource_changed` because the check otherwise allocates
+            // a map over every shader each frame, forever; library assets only
+            // stream in while the asset set is actually changing.
+            .add_systems(
+                PreUpdate,
+                ensure_shader_validator.run_if(resource_changed::<Assets<Shader>>),
+            )
+            .add_systems(Update, report_material_problems.after(resolve_material_refs));
     }
 }
 
@@ -186,6 +197,7 @@ impl Plugin for MaterialResolverPlugin {
 /// Keyed on the shader uuid rather than driven off the resolve, because the
 /// validator needs bevy_pbr's libraries and those land a frame after the first
 /// material resolves. A fresh uuid per compile catches recompiles too.
+#[cfg(feature = "editor")]
 fn report_material_problems(
     mut checked: Local<HashMap<String, (Uuid, usize)>>,
     cache: Res<MaterialCache>,
@@ -250,6 +262,7 @@ fn report_material_problems(
 /// land in `Assets<Shader>` over the frames that follow, so a validator built
 /// on the first one that appears is missing most of the imports a material
 /// needs.
+#[cfg(feature = "editor")]
 fn ensure_shader_validator(
     mut commands: Commands,
     existing: Option<Res<super::validate::ShaderValidator>>,

--- a/crates/renzora_shader/src/material/validate.rs
+++ b/crates/renzora_shader/src/material/validate.rs
@@ -3,7 +3,6 @@
 
 use bevy::prelude::*;
 use bevy::shader::{Shader, ShaderImport};
-use naga::valid::{Capabilities, ValidationFlags, Validator};
 use naga_oil::compose::{Composer, NagaModuleDescriptor, ShaderDefValue, ShaderType};
 use renzora::content_problems::{ContentProblem, ProblemSeverity};
 use std::collections::HashMap;
@@ -150,8 +149,7 @@ impl ShaderValidator {
         let label = || defines.join(",");
         match module {
             Ok(module) => {
-                let mut validator = Validator::new(ValidationFlags::all(), Capabilities::all());
-                if let Err(err) = validator.validate(&module) {
+                if let Err(err) = renzora::wgsl::validate(&module) {
                     errors.push(ValidationError {
                         defines: label(),
                         // Debug dump — validation errors have no `emit_to_string`.

--- a/crates/renzora_shader/src/material/validate.rs
+++ b/crates/renzora_shader/src/material/validate.rs
@@ -3,11 +3,20 @@
 
 use bevy::prelude::*;
 use bevy::shader::{Shader, ShaderImport};
-use naga_oil::compose::{Composer, NagaModuleDescriptor, ShaderDefValue, ShaderType};
+use naga_oil::compose::{
+    Composer, ComposerError, ComposerErrorInner, ErrSource, NagaModuleDescriptor,
+    ShaderDefValue, ShaderType,
+};
 use renzora::content_problems::{ContentProblem, ProblemSeverity};
 use std::collections::HashMap;
 
 use super::codegen::CompileResult;
+
+/// naga_oil tags composed-module spans with the source-module index in the
+/// high bits (`compose/mod.rs` — private there, so mirrored here). Index 0 is
+/// the top-level generated source; anything else is a bevy_pbr library,
+/// whose errors are engine bugs, not user bugs.
+const SPAN_SHIFT: usize = 21;
 
 #[derive(Debug, Clone)]
 pub struct ValidationError {
@@ -16,6 +25,10 @@ pub struct ValidationError {
     pub defines: String,
     /// codespan-rendered diagnostic against the composed shader source.
     pub message: String,
+    /// 1-based line in the *generated* fragment shader, when the span points
+    /// at it. `None` for errors inside bevy_pbr's libraries or in
+    /// preprocessor directives — those are engine bugs, not user bugs.
+    pub line: Option<u32>,
 }
 
 impl std::fmt::Display for ValidationError {
@@ -71,6 +84,7 @@ impl ShaderValidator {
             return Err(vec![ValidationError {
                 defines: String::new(),
                 message: format!("codegen errors: {}", result.errors.join("; ")),
+                line: None,
             }]);
         }
 
@@ -98,26 +112,35 @@ impl ShaderValidator {
     /// reads as three faults. A message only some configurations produce keeps
     /// its `[defines: …]` prefix, because there the configuration *is* the
     /// finding.
-    pub fn problems_for_source(&mut self, source: &str) -> Vec<ContentProblem> {
+    ///
+    /// `node_lines` is the source map `CompileResult::node_lines` produced
+    /// (and the embedded artifact's meta persisted) at codegen time; it is what
+    /// puts an error on a node. Pass `&[]` when the source came from
+    /// somewhere with no map — the problem then carries no line or node.
+    pub fn problems_for_source(
+        &mut self,
+        source: &str,
+        node_lines: &[(u64, u32, u32)],
+    ) -> Vec<ContentProblem> {
         let mut errors = Vec::new();
         for defines in FRAGMENT_CONFIGS {
             self.compile_one(source, defines, &mut errors);
         }
 
         let mut order: Vec<String> = Vec::new();
-        let mut configs: HashMap<String, Vec<String>> = HashMap::new();
+        let mut configs: HashMap<String, (Vec<String>, Option<u32>)> = HashMap::new();
         for error in errors {
             let seen = configs.entry(error.message.clone()).or_insert_with(|| {
                 order.push(error.message.clone());
-                Vec::new()
+                (Vec::new(), error.line)
             });
-            seen.push(error.defines);
+            seen.0.push(error.defines);
         }
 
         order
             .into_iter()
             .map(|message| {
-                let seen = &configs[&message];
+                let (seen, line) = &configs[&message];
                 let message = if seen.len() == FRAGMENT_CONFIGS.len() {
                     message
                 } else {
@@ -126,7 +149,8 @@ impl ShaderValidator {
                 ContentProblem {
                     severity: ProblemSeverity::Error,
                     message,
-                    line: None,
+                    line: line.map(|l| l as usize),
+                    node_id: line.and_then(|l| super::codegen::node_for_line(node_lines, l)),
                 }
             })
             .collect()
@@ -153,16 +177,55 @@ impl ShaderValidator {
                     errors.push(ValidationError {
                         defines: label(),
                         // Debug dump — validation errors have no `emit_to_string`.
+                        // Unreachable in practice: `make_naga_module` already
+                        // validated the composed module, so its own error
+                        // (with a decodable span) fires first. No line here.
                         message: format!("{err:?}"),
+                        line: None,
                     });
                 }
             }
             Err(err) => errors.push(ValidationError {
                 defines: label(),
+                line: error_line(&err, &self.composer),
                 message: err.emit_to_string(&self.composer),
             }),
         }
     }
+}
+
+/// The 1-based line a `ComposerError` points at in the *generated* source —
+/// decodable because naga_oil's preprocessor is line-preserving, so a line in
+/// the preprocessed text is the same line in what codegen emitted.
+///
+/// Only `ErrSource::Constructing` (the top-level generated shader) is
+/// decodable. Errors inside imported bevy_pbr modules, and preprocessor
+/// errors on directive lines, return `None`: they are engine bugs, and a
+/// node attribution would send the user hunting in the wrong place.
+fn error_line(err: &ComposerError, composer: &Composer) -> Option<u32> {
+    let ErrSource::Constructing { .. } = err.source else {
+        return None;
+    };
+    let source = err.source.source(composer);
+    let range = match &err.inner {
+        ComposerErrorInner::WgslParseError(parse) => {
+            parse.labels().next().and_then(|(span, _)| span.to_range())
+        }
+        ComposerErrorInner::ShaderValidationError(with_span) => {
+            with_span.spans().last().and_then(|(span, _)| span.to_range())
+        }
+        _ => None,
+    }?;
+    if range.start >> SPAN_SHIFT != 0 {
+        return None;
+    }
+    let byte = (range.start & ((1 << SPAN_SHIFT) - 1)).saturating_sub(err.source.offset());
+    Some(line_of_byte(&source, byte))
+}
+
+/// 1-based line number of byte offset `byte` in `source`.
+fn line_of_byte(source: &str, byte: usize) -> u32 {
+    source[..byte.min(source.len())].matches('\n').count() as u32 + 1
 }
 
 /// What `PipelineCache` and `MeshPipeline` put in front of every material
@@ -441,5 +504,47 @@ mod tests {
                     .join("\n")
             )
         });
+    }
+
+    /// A broken `custom/code` snippet must point at its own line — and,
+    /// through the source map, at its own node.
+    #[test]
+    fn a_broken_snippet_attributes_line_and_node() {
+        use crate::material::graph::PinValue;
+
+        let mut graph = MaterialGraph::new("attr", crate::material::graph::MaterialDomain::Surface);
+        let node = graph.add_node("custom/code", [0.0, 0.0]);
+        graph
+            .get_node_mut(node)
+            .unwrap()
+            .input_values
+            .insert(
+                "code".to_string(),
+                PinValue::String("result = vec4<f32>(no_such_symbol, 0.0, 0.0, 1.0);".to_string()),
+            );
+        let output_id = graph.output_node().unwrap().id;
+        graph.connect(node, "result", output_id, "base_color");
+
+        let result = codegen::compile(&graph);
+        let snippet_line = result
+            .fragment_shader
+            .lines()
+            .position(|l| l.contains("no_such_symbol"))
+            .map(|i| i as u32 + 1)
+            .unwrap();
+
+        let mut validator = validator();
+        let errors = validator
+            .validate(&result)
+            .expect_err("the snippet must fail to compile");
+        assert!(
+            errors.iter().any(|e| e.line == Some(snippet_line)),
+            "no error on the snippet's line {snippet_line}: {errors:?}"
+        );
+
+        let problems = validator.problems_for_source(&result.fragment_shader, &result.node_lines);
+        assert_eq!(problems.len(), 1, "one fault, one row: {problems:?}");
+        assert_eq!(problems[0].line, Some(snippet_line as usize));
+        assert_eq!(problems[0].node_id, Some(node));
     }
 }

--- a/crates/renzora_shader/src/material/validate.rs
+++ b/crates/renzora_shader/src/material/validate.rs
@@ -1,0 +1,447 @@
+//! Compiles generated material shaders the way the engine does — naga_oil's
+//! composer over the app's own `Assets<Shader>`, then naga.
+
+use bevy::prelude::*;
+use bevy::shader::{Shader, ShaderImport};
+use naga::valid::{Capabilities, ValidationFlags, Validator};
+use naga_oil::compose::{Composer, NagaModuleDescriptor, ShaderDefValue, ShaderType};
+use renzora::content_problems::{ContentProblem, ProblemSeverity};
+use std::collections::HashMap;
+
+use super::codegen::CompileResult;
+
+#[derive(Debug, Clone)]
+pub struct ValidationError {
+    /// The pipeline defines this configuration was compiled under, for
+    /// example `"VERTEX_UVS_A,VERTEX_COLORS"`. Empty for the no-defines pass.
+    pub defines: String,
+    /// codespan-rendered diagnostic against the composed shader source.
+    pub message: String,
+}
+
+impl std::fmt::Display for ValidationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "[defines: {}] {}", self.defines, self.message)
+    }
+}
+
+/// A composer preloaded with every shader library an app has registered.
+///
+/// Building one walks all of bevy_pbr's modules, so it is built once and held
+/// rather than made per material.
+#[derive(Resource)]
+pub struct ShaderValidator {
+    composer: Composer,
+    library_count: usize,
+}
+
+impl ShaderValidator {
+    /// Load the shader *libraries* in `shaders` into a composer.
+    ///
+    /// A module has to be added after everything it imports, so this recurses
+    /// through `Shader::imports` rather than trusting `Assets` iteration order.
+    pub fn new(shaders: &Assets<Shader>) -> Self {
+        let by_path = importable_libraries(shaders);
+        let mut composer = Composer::default();
+        for shader in by_path.values() {
+            add_module(&mut composer, &by_path, shader);
+        }
+        Self {
+            library_count: by_path.len(),
+            composer,
+        }
+    }
+
+    /// How many libraries this composer was built from.
+    ///
+    /// Shader libraries stream in as assets over several frames, so a validator
+    /// built early knows only some of them and rejects valid shaders for an
+    /// import it has not seen. Callers compare this against
+    /// [`library_count`] to notice they are holding a stale one.
+    pub fn library_count(&self) -> usize {
+        self.library_count
+    }
+
+    /// Compile a [`CompileResult`]'s fragment shader, once per pipeline-define
+    /// configuration codegen branches on. `Err` carries one entry per failing
+    /// configuration.
+    pub fn validate(&mut self, result: &CompileResult) -> Result<(), Vec<ValidationError>> {
+        // A codegen error already means the shader is known-incomplete. Compiling
+        // its half-built output reports secondary noise instead of the cause.
+        if !result.errors.is_empty() {
+            return Err(vec![ValidationError {
+                defines: String::new(),
+                message: format!("codegen errors: {}", result.errors.join("; ")),
+            }]);
+        }
+
+        let mut errors = Vec::new();
+        for defines in FRAGMENT_CONFIGS {
+            self.compile_one(&result.fragment_shader, defines, &mut errors);
+        }
+
+        // `result.vertex_shader` is left alone: nothing writes it to disk or binds it.
+
+        if errors.is_empty() { Ok(()) } else { Err(errors) }
+    }
+
+    /// What the Problems panel shows for one material: whatever the shader
+    /// compiler rejects about the WGSL that is actually going to be bound.
+    ///
+    /// Takes the source rather than a [`CompileResult`] so it covers a shader
+    /// embedded in a saved `.material` as well as one freshly generated — the
+    /// resolver has both, and only one of them ever had a `CompileResult`.
+    ///
+    /// An empty result is what clears a repaired file from the panel.
+    ///
+    /// One entry per distinct compiler message, not per configuration: a broken
+    /// expression fails under all of them, and three copies of one diagnostic
+    /// reads as three faults. A message only some configurations produce keeps
+    /// its `[defines: …]` prefix, because there the configuration *is* the
+    /// finding.
+    pub fn problems_for_source(&mut self, source: &str) -> Vec<ContentProblem> {
+        let mut errors = Vec::new();
+        for defines in FRAGMENT_CONFIGS {
+            self.compile_one(source, defines, &mut errors);
+        }
+
+        let mut order: Vec<String> = Vec::new();
+        let mut configs: HashMap<String, Vec<String>> = HashMap::new();
+        for error in errors {
+            let seen = configs.entry(error.message.clone()).or_insert_with(|| {
+                order.push(error.message.clone());
+                Vec::new()
+            });
+            seen.push(error.defines);
+        }
+
+        order
+            .into_iter()
+            .map(|message| {
+                let seen = &configs[&message];
+                let message = if seen.len() == FRAGMENT_CONFIGS.len() {
+                    message
+                } else {
+                    format!("[defines: {}] {message}", seen.join(" | "))
+                };
+                ContentProblem {
+                    severity: ProblemSeverity::Error,
+                    message,
+                    line: None,
+                }
+            })
+            .collect()
+    }
+
+    fn compile_one(&mut self, source: &str, defines: &[&str], errors: &mut Vec<ValidationError>) {
+        let mut shader_defs = pipeline_shader_defs();
+        for d in defines {
+            shader_defs.insert((*d).to_string(), ShaderDefValue::Bool(true));
+        }
+
+        let module = self.composer.make_naga_module(NagaModuleDescriptor {
+            source,
+            file_path: "generated.wgsl",
+            shader_type: ShaderType::Wgsl,
+            shader_defs,
+            ..Default::default()
+        });
+
+        let label = || defines.join(",");
+        match module {
+            Ok(module) => {
+                let mut validator = Validator::new(ValidationFlags::all(), Capabilities::all());
+                if let Err(err) = validator.validate(&module) {
+                    errors.push(ValidationError {
+                        defines: label(),
+                        // Debug dump — validation errors have no `emit_to_string`.
+                        message: format!("{err:?}"),
+                    });
+                }
+            }
+            Err(err) => errors.push(ValidationError {
+                defines: label(),
+                message: err.emit_to_string(&self.composer),
+            }),
+        }
+    }
+}
+
+/// What `PipelineCache` and `MeshPipeline` put in front of every material
+/// shader they compile. Without them bevy_pbr's own libraries do not
+/// preprocess, so this is the floor the generated code sits on rather than a
+/// choice.
+///
+/// The storage-buffer count is a device limit in the real pipeline
+/// (`PipelineCache::new`). There is no device here, so it takes wgpu's default
+/// — the branch every desktop backend picks.
+fn pipeline_shader_defs() -> HashMap<String, ShaderDefValue> {
+    let limits = bevy::render::settings::WgpuLimits::default();
+    HashMap::from([
+        (
+            "AVAILABLE_STORAGE_BUFFER_BINDINGS".to_string(),
+            ShaderDefValue::UInt(limits.max_storage_buffers_per_shader_stage),
+        ),
+        (
+            "MATERIAL_BIND_GROUP".to_string(),
+            ShaderDefValue::UInt(bevy::pbr::MATERIAL_BIND_GROUP_INDEX as u32),
+        ),
+        (
+            "VERTEX_OUTPUT_INSTANCE_INDEX".to_string(),
+            ShaderDefValue::Bool(true),
+        ),
+        ("VERTEX_POSITIONS".to_string(), ShaderDefValue::Bool(true)),
+    ])
+}
+
+/// Every configuration that ships gets compiled: with and without the mesh
+/// attributes, and with and without a camera's environment map. The prepass
+/// defines are left out — the prepass builds its own pipeline from a different
+/// entry point, so those branches are not part of this shader's compilation.
+const FRAGMENT_CONFIGS: [&[&str]; 3] = [
+    &[],
+    &["VERTEX_UVS_A", "VERTEX_COLORS"],
+    &["VERTEX_UVS_A", "VERTEX_COLORS", "ENVIRONMENT_MAP"],
+];
+
+/// The importable libraries in `shaders`, keyed by import path.
+///
+/// Only `ShaderImport::Custom` modules qualify — that variant means the
+/// source declared `#define_import_path`, which is what makes it importable.
+/// The rest are plain files, generated material shaders among them, and
+/// adding those puts every compiled material in the import namespace.
+fn importable_libraries(shaders: &Assets<Shader>) -> HashMap<&ShaderImport, &Shader> {
+    shaders
+        .iter()
+        .map(|(_, s)| (&s.import_path, s))
+        .filter(|(path, _)| matches!(path, ShaderImport::Custom(_)))
+        .collect()
+}
+
+/// The number of shader libraries currently registered — what
+/// [`ShaderValidator::new`] builds from right now.
+pub fn library_count(shaders: &Assets<Shader>) -> usize {
+    importable_libraries(shaders).len()
+}
+
+fn add_module(composer: &mut Composer, by_path: &HashMap<&ShaderImport, &Shader>, shader: &Shader) {
+    if composer.contains_module(&shader.import_path.module_name()) {
+        return;
+    }
+    for import in &shader.imports {
+        if let Some(dep) = by_path.get(import) {
+            add_module(composer, by_path, dep);
+        }
+    }
+    // A library that fails to add is one this validator cannot resolve imports
+    // through; the material that needs it then fails with that name in the
+    // message, which is more useful than a panic here naming only the library.
+    let _ = composer.add_composable_module(shader.into());
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::material::codegen;
+    use crate::material::graph::{MaterialGraph, PinDir, PinType};
+    use crate::material::nodes;
+    use std::path::PathBuf;
+
+    fn materials_dir() -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../../assets/materials")
+    }
+
+    /// A validator over the shader libraries a real engine app registers.
+    ///
+    /// `headless_app` builds `RenderPlugin` with no backend, so there is no
+    /// adapter and no `RenderApp` — but `PbrPlugin::build` still runs and its
+    /// shader libraries are ordinary assets, which is all the composer needs.
+    fn validator() -> ShaderValidator {
+        let mut app = renzora_test_harness::headless_app();
+        // The libraries are embedded assets, so they arrive through the asset
+        // server rather than at plugin-build time. One frame is enough.
+        app.update();
+        let shaders = app.world().resource::<Assets<Shader>>();
+        assert!(
+            shaders.iter().any(|(_, s)| s.import_path.module_name().as_ref() == "bevy_pbr::pbr_functions"),
+            "bevy_pbr's shader libraries are missing; the composer would resolve no imports"
+        );
+        ShaderValidator::new(shaders)
+    }
+
+    #[test]
+    fn every_shipped_material_compiles_to_valid_wgsl() {
+        let mut validator = validator();
+        let dir = materials_dir();
+        let mut count = 0;
+        let mut failures = Vec::new();
+        for entry in std::fs::read_dir(&dir).unwrap_or_else(|e| panic!("read {}: {e}", dir.display())) {
+            let path = entry.unwrap().path();
+            if path.extension().and_then(|e| e.to_str()) != Some("material") {
+                continue;
+            }
+            count += 1;
+            let json = std::fs::read_to_string(&path).unwrap();
+            let graph: MaterialGraph = match serde_json::from_str(&json) {
+                Ok(g) => g,
+                Err(e) => {
+                    failures.push(format!("{}: graph JSON does not parse: {e}", path.display()));
+                    continue;
+                }
+            };
+            let result = codegen::compile(&graph);
+            if let Err(errors) = validator.validate(&result) {
+                for err in errors {
+                    failures.push(format!("{}: {err}", path.display()));
+                }
+            }
+        }
+        assert!(count > 0, "no .material files found under {}", dir.display());
+        assert!(
+            failures.is_empty(),
+            "{count} materials, {} validation failures:\n{}",
+            failures.len(),
+            failures.join("\n\n")
+        );
+    }
+
+    /// Build a single-node graph exercising `node_type`: add the node, wire
+    /// every one of its output pins into a compatible input on the output
+    /// node, and compile. Nodes whose outputs no output pin accepts
+    /// (Texture2D, Sampler, String) are wired through one intermediate node
+    /// that does accept them — codegen only visits nodes reachable from the
+    /// output node, so an unconnected node generates nothing and the test
+    /// passes vacuously.
+    fn graph_exercising(node_type: &str) -> Option<MaterialGraph> {
+        let def = nodes::node_def(node_type)?;
+        let mut graph = MaterialGraph::new("coverage", crate::material::graph::MaterialDomain::Surface);
+        let node_id = graph.add_node(node_type, [0.0, 0.0]);
+        let output_id = graph.output_node().unwrap().id;
+
+        let outputs: Vec<_> = (def.pins)()
+            .into_iter()
+            .filter(|p| p.direction == PinDir::Output)
+            .collect();
+
+        for pin in &outputs {
+            // A pin with no route to the output node stays disconnected.
+            // Other pins can still reach it.
+            let _ = try_wire(&mut graph, node_id, &pin.name, pin.pin_type, output_id);
+        }
+        Some(graph)
+    }
+
+    /// Wire `from_pin` on `from_node` toward the output node, directly or via
+    /// one intermediate. Returns the connection made.
+    fn try_wire(
+        graph: &mut MaterialGraph,
+        from_node: u64,
+        from_pin: &str,
+        from_type: PinType,
+        output_id: u64,
+    ) -> Option<()> {
+        // Direct: a compatible input on the output node.
+        let output_def = nodes::node_def(&graph.get_node(output_id)?.node_type)?;
+        if let Some(target) = (output_def.pins)().into_iter().find(|p| {
+            p.direction == PinDir::Input && PinType::compatible(from_type, p.pin_type)
+        }) {
+            graph.connect(from_node, from_pin, output_id, &target.name);
+            return Some(());
+        }
+        // Via one intermediate node that accepts this type and can itself
+        // reach the output node.
+        for mid in nodes::ALL_NODES {
+            if mid.node_type.starts_with("output/") || mid.node_type.starts_with("function/") {
+                continue;
+            }
+            let mid_pins = (mid.pins)();
+            let Some(mid_input) = mid_pins.iter().find(|p| {
+                p.direction == PinDir::Input && PinType::compatible(from_type, p.pin_type)
+            }) else {
+                continue;
+            };
+            let Some(mid_output) = mid_pins.iter().find(|p| {
+                p.direction == PinDir::Output
+                    && (output_def.pins)().iter().any(|t| {
+                        t.direction == PinDir::Input && PinType::compatible(p.pin_type, t.pin_type)
+                    })
+            }) else {
+                continue;
+            };
+            let mid_id = graph.add_node(mid.node_type, [100.0, 0.0]);
+            let mid_input_name = mid_input.name.clone();
+            let mid_output_name = mid_output.name.clone();
+            graph.connect(from_node, from_pin, mid_id, &mid_input_name);
+            let target = (output_def.pins)()
+                .into_iter()
+                .find(|t| {
+                    t.direction == PinDir::Input
+                        && PinType::compatible(mid_output.pin_type, t.pin_type)
+                })?;
+            graph.connect(mid_id, &mid_output_name, output_id, &target.name);
+            return Some(());
+        }
+        None
+    }
+
+    #[test]
+    fn every_node_type_generates_valid_wgsl() {
+        let mut validator = validator();
+        let mut failures = Vec::new();
+        let mut count = 0;
+        for def in nodes::ALL_NODES {
+            let node_type = def.node_type;
+            // Output nodes are the sink the harness builds around, and
+            // function bracket nodes only codegen inside a MaterialFunction.
+            if node_type.starts_with("output/") || node_type.starts_with("function/") {
+                continue;
+            }
+            count += 1;
+            let Some(graph) = graph_exercising(node_type) else {
+                failures.push(format!("{node_type}: unknown to nodes::node_def"));
+                continue;
+            };
+            let result = codegen::compile(&graph);
+            if let Err(errors) = validator.validate(&result) {
+                for err in errors {
+                    failures.push(format!("{node_type}: {err}"));
+                }
+            }
+        }
+        assert!(
+            failures.is_empty(),
+            "{count} node types exercised, {} validation failures:\n{}",
+            failures.len(),
+            failures.join("\n\n")
+        );
+    }
+
+    /// `param/bool` is the only Bool *output* pin in the node set and its
+    /// codegen emits a real WGSL `bool`, which `cast_expr` used to hand to a
+    /// float pin unchanged.
+    #[test]
+    fn param_bool_wired_into_float_pin_validates() {
+        let mut graph = MaterialGraph::new(
+            "bool_into_float",
+            crate::material::graph::MaterialDomain::Surface,
+        );
+        let param = graph.add_node("param/bool", [0.0, 0.0]);
+        let output_id = graph.output_node().unwrap().id;
+        graph.connect(param, "value", output_id, "metallic");
+
+        let result = codegen::compile(&graph);
+        validator().validate(&result).unwrap_or_else(|errors| {
+            panic!(
+                "param/bool → metallic must validate:\n{}",
+                errors
+                    .iter()
+                    .map(|e| e.to_string())
+                    .collect::<Vec<_>>()
+                    .join("\n")
+            )
+        });
+    }
+}

--- a/crates/renzora_shader/src/material/validate.rs
+++ b/crates/renzora_shader/src/material/validate.rs
@@ -320,17 +320,46 @@ mod tests {
     /// `headless_app` builds `RenderPlugin` with no backend, so there is no
     /// adapter and no `RenderApp` — but `PbrPlugin::build` still runs and its
     /// shader libraries are ordinary assets, which is all the composer needs.
-    fn validator() -> ShaderValidator {
-        let mut app = renzora_test_harness::headless_app();
-        // The libraries are embedded assets, so they arrive through the asset
-        // server rather than at plugin-build time. One frame is enough.
-        app.update();
-        let shaders = app.world().resource::<Assets<Shader>>();
-        assert!(
-            shaders.iter().any(|(_, s)| s.import_path.module_name().as_ref() == "bevy_pbr::pbr_functions"),
-            "bevy_pbr's shader libraries are missing; the composer would resolve no imports"
-        );
-        ShaderValidator::new(shaders)
+    ///
+    /// Built once per process and shared: the libraries are embedded assets
+    /// that stream in over several frames through the shared IO task pool,
+    /// and several headless apps pumping in parallel starve each other — an
+    /// app whose turn has not come yet sees a partial set, and its composer
+    /// then reports the missing ones as unresolved imports. `get_or_init`
+    /// blocks the other callers, so the one app that loads does so alone.
+    /// `compile_one` only composes from the registered modules, so sharing
+    /// the validator across tests is safe.
+    fn validator() -> std::sync::MutexGuard<'static, ShaderValidator> {
+        static VALIDATOR: std::sync::OnceLock<std::sync::Mutex<ShaderValidator>> =
+            std::sync::OnceLock::new();
+        let mutex = VALIDATOR.get_or_init(|| {
+            let mut app = renzora_test_harness::headless_app();
+            // Pump until the library set stops growing (and is non-empty —
+            // frame one reports zero, which is "stable" too).
+            let mut last = 0usize;
+            let mut stable = 0;
+            for _ in 0..500 {
+                app.update();
+                let n = importable_libraries(app.world().resource::<Assets<Shader>>()).len();
+                if n == last {
+                    stable += 1;
+                    if n > 0 && stable >= 3 {
+                        break;
+                    }
+                } else {
+                    stable = 0;
+                    last = n;
+                }
+            }
+            let shaders = app.world().resource::<Assets<Shader>>();
+            assert!(
+                shaders.iter().any(|(_, s)| s.import_path.module_name().as_ref() == "bevy_pbr::pbr_functions"),
+                "bevy_pbr's shader libraries are missing; the composer would resolve no imports"
+            );
+            std::sync::Mutex::new(ShaderValidator::new(shaders))
+        });
+        // A panicking test poisons the lock; the validator itself is intact.
+        mutex.lock().unwrap_or_else(|e| e.into_inner())
     }
 
     #[test]
@@ -546,5 +575,204 @@ mod tests {
         assert_eq!(problems.len(), 1, "one fault, one row: {problems:?}");
         assert_eq!(problems[0].line, Some(snippet_line as usize));
         assert_eq!(problems[0].node_id, Some(node));
+    }
+
+    // ── Math-node vectorization ─────────────────────────────────────────────
+
+    /// The five ranks a math node can latch to, each with the parameter node
+    /// whose `value` output drives it.
+    const RANK_SOURCES: [(&str, PinType); 5] = [
+        ("param/float", PinType::Float),
+        ("param/vec2", PinType::Vec2),
+        ("param/vec3", PinType::Vec3),
+        ("param/vec4", PinType::Vec4),
+        ("param/color", PinType::Color),
+    ];
+
+    /// What feeds the node's second dynamic input pin, when it has one.
+    #[derive(Clone, Copy, Debug)]
+    enum Sibling {
+        Unconnected,
+        Scalar,
+        SameRank,
+    }
+
+    /// One matrix cell: `node_type` driven on its first dynamic input by
+    /// `src_type`'s `value` output, `result` wired into the output node's
+    /// `base_color` so codegen actually visits the node.
+    fn vectorization_cell(
+        node_type: &str,
+        src_type: &str,
+        sibling: Sibling,
+    ) -> (MaterialGraph, u64) {
+        use crate::material::graph::is_dynamic_pin;
+
+        let mut graph =
+            MaterialGraph::new("vec", crate::material::graph::MaterialDomain::Surface);
+        let m = graph.add_node(node_type, [0.0, 0.0]);
+        let s = graph.add_node(src_type, [-200.0, 0.0]);
+        let output_id = graph.output_node().unwrap().id;
+
+        let def = nodes::node_def(node_type).unwrap();
+        let dyn_inputs: Vec<String> = (def.pins)()
+            .into_iter()
+            .filter(|p| p.direction == PinDir::Input && is_dynamic_pin(node_type, &p.name))
+            .map(|p| p.name)
+            .collect();
+        graph.connect(s, "value", m, &dyn_inputs[0]);
+        if dyn_inputs.len() > 1 {
+            match sibling {
+                Sibling::Unconnected => {}
+                Sibling::Scalar => {
+                    let f = graph.add_node("param/float", [-200.0, 100.0]);
+                    graph.connect(f, "value", m, &dyn_inputs[1]);
+                }
+                Sibling::SameRank => {
+                    graph.connect(s, "value", m, &dyn_inputs[1]);
+                }
+            }
+        }
+        graph.connect(m, "result", output_id, "base_color");
+        (graph, m)
+    }
+
+    /// Every math node × every driving rank × every sibling shape must latch
+    /// to the widest wire and still compile to valid WGSL — this is where the
+    /// rank-aware guard literals (`max({b}, vec4<f32>(0.000001))` and friends)
+    /// get exercised, since a scalar guard under a latched vector node is a
+    /// naga type error.
+    #[test]
+    fn math_nodes_vectorize_to_widest_wire() {
+        use crate::material::graph::{is_dynamic_pin, resolve_math_ranks};
+
+        let mut validator = validator();
+        let mut failures = Vec::new();
+        let mut count = 0;
+        for def in nodes::ALL_NODES {
+            let node_type = def.node_type;
+            if !node_type.starts_with("math/") {
+                continue;
+            }
+            let dynamic_inputs = (def.pins)()
+                .into_iter()
+                .filter(|p| p.direction == PinDir::Input && is_dynamic_pin(node_type, &p.name))
+                .count();
+            for (src_type, rank) in RANK_SOURCES {
+                let siblings: &[Sibling] = if dynamic_inputs > 1 {
+                    &[Sibling::Unconnected, Sibling::Scalar, Sibling::SameRank]
+                } else {
+                    &[Sibling::Unconnected]
+                };
+                for sibling in siblings {
+                    count += 1;
+                    let (graph, m) = vectorization_cell(node_type, src_type, *sibling);
+                    let latched = resolve_math_ranks(&graph)
+                        .get(&m)
+                        .copied()
+                        .unwrap_or(PinType::Float);
+                    if latched != rank {
+                        failures.push(format!(
+                            "{node_type} driven by {src_type} ({sibling:?}): latched {latched:?}, want {rank:?}"
+                        ));
+                        continue;
+                    }
+                    let result = codegen::compile(&graph);
+                    if let Err(errors) = validator.validate(&result) {
+                        for err in errors {
+                            failures.push(format!(
+                                "{node_type} driven by {src_type} ({sibling:?}): {err}"
+                            ));
+                        }
+                    }
+                }
+            }
+        }
+        assert!(
+            failures.is_empty(),
+            "{count} vectorization cells, {} failures:\n{}",
+            failures.len(),
+            failures.join("\n\n")
+        );
+    }
+
+    /// A wide consumer on `result` must not widen the node's inputs — the
+    /// node never dictates types downstream, the sink's `cast_expr` narrows.
+    #[test]
+    fn math_node_does_not_latch_from_downstream() {
+        use crate::material::graph::resolve_math_ranks;
+
+        let mut graph =
+            MaterialGraph::new("no_back_latch", crate::material::graph::MaterialDomain::Surface);
+        let m = graph.add_node("math/add", [0.0, 0.0]);
+        let output_id = graph.output_node().unwrap().id;
+        // base_color is a Color (rank-4) sink.
+        graph.connect(m, "result", output_id, "base_color");
+        let latched = resolve_math_ranks(&graph)
+            .get(&m)
+            .copied()
+            .unwrap_or(PinType::Float);
+        assert_eq!(latched, PinType::Float, "downstream sink must not latch");
+
+        let result = codegen::compile(&graph);
+        validator().validate(&result).unwrap_or_else(|errors| {
+            panic!("unlatched add into base_color must validate: {errors:?}")
+        });
+    }
+
+    /// Removing the wide wire drops the node back to Float, and both shapes
+    /// compile — resolution is recomputed, never remembered.
+    #[test]
+    fn math_node_unlatches_when_the_wide_wire_detaches() {
+        use crate::material::graph::resolve_math_ranks;
+
+        let mut validator = validator();
+        let (mut graph, m) = vectorization_cell("math/add", "param/vec4", Sibling::Unconnected);
+        assert_eq!(resolve_math_ranks(&graph)[&m], PinType::Vec4);
+        let result = codegen::compile(&graph);
+        validator
+            .validate(&result)
+            .unwrap_or_else(|e| panic!("latched vec4 add must validate: {e:?}"));
+
+        graph.disconnect(m, "a");
+        assert_eq!(resolve_math_ranks(&graph)[&m], PinType::Float);
+        let result = codegen::compile(&graph);
+        validator
+            .validate(&result)
+            .unwrap_or_else(|e| panic!("detached add must validate as Float: {e:?}"));
+    }
+
+    /// The divide guard splats its epsilon at the latched rank. Widening
+    /// through `cast_expr` instead would fill w with `1.0`, clamping the
+    /// guard's last component against 1.0 rather than the epsilon.
+    #[test]
+    fn divide_guard_splats_at_latched_rank() {
+        let (graph, _m) = vectorization_cell("math/divide", "param/vec4", Sibling::Unconnected);
+        let result = codegen::compile(&graph);
+        assert!(
+            result.fragment_shader.contains("vec4<f32>(0.000001)"),
+            "guard literal must splat at the latched rank:\n{}",
+            result.fragment_shader
+        );
+    }
+
+    /// Latched ranks are re-derived from the loaded graph: a serialized
+    /// vec3-latched Add loads, resolves identically, and validates.
+    #[test]
+    fn latched_graph_round_trips_through_serialization() {
+        use crate::material::graph::resolve_math_ranks;
+
+        let (graph, m) = vectorization_cell("math/add", "param/vec3", Sibling::Scalar);
+        let json = serde_json::to_string(&graph).unwrap();
+        let loaded: MaterialGraph = serde_json::from_str(&json).unwrap();
+        assert_eq!(
+            resolve_math_ranks(&graph).get(&m),
+            resolve_math_ranks(&loaded).get(&m),
+            "ranks are a pure function of the graph; a round-trip must not move them"
+        );
+
+        let result = codegen::compile(&loaded);
+        validator()
+            .validate(&result)
+            .unwrap_or_else(|e| panic!("round-tripped latched graph must validate: {e:?}"));
     }
 }

--- a/crates/renzora_shader/tests/material_problems.rs
+++ b/crates/renzora_shader/tests/material_problems.rs
@@ -226,10 +226,33 @@ fn a_broken_material_is_reported_against_its_own_path() {
     );
 }
 
+/// The Console panel's buffer must hear a broken material too — the Problems
+/// panel alone leaves anyone watching the console blind.
+#[test]
+fn a_broken_material_reaches_the_console() {
+    renzora::console_log::init_global_log_buffer();
+    let buffer = renzora::console_log::get_global_log_buffer().unwrap();
+
+    let mut f = Fixture::new("console");
+    f.write(BROKEN);
+    f.spawn_user();
+    f.pump();
+
+    let entries = buffer.0.lock().unwrap();
+    assert!(
+        entries.iter().any(|e| {
+            e.level == renzora::console_log::LogLevel::Error
+                && e.category == "Material"
+                && e.message.contains("t.material")
+                && e.message.contains("no_such_symbol")
+        }),
+        "no Material error in the console buffer"
+    );
+}
+
 /// The one the user asked for: a repaired material must stop being reported.
 #[test]
-fn repairing_a_material_clears_its_report() {
-    let mut f = Fixture::new("repair");
+fn repairing_a_material_clears_its_report() {    let mut f = Fixture::new("repair");
     f.write(BROKEN);
     f.spawn_user();
     f.pump();

--- a/crates/renzora_shader/tests/material_problems.rs
+++ b/crates/renzora_shader/tests/material_problems.rs
@@ -12,8 +12,9 @@ use renzora_shader::material::resolver::{MaterialCache, MaterialResolved};
 ///
 /// `custom/code` is the one node that still lets a user write arbitrary WGSL,
 /// which makes it the only way to author a graph that codegen accepts and the
-/// shader compiler rejects — exactly the case the panel exists for.
-fn graph_with_snippet(name: &str, code: &str) -> MaterialGraph {
+/// shader compiler rejects — exactly the case the panel exists for. Returns
+/// the snippet node's id so a test can assert errors land on it.
+fn graph_with_snippet(name: &str, code: &str) -> (MaterialGraph, u64) {
     let mut graph = MaterialGraph::new(name, MaterialDomain::Surface);
     let node = graph.add_node("custom/code", [0.0, 0.0]);
     graph
@@ -23,7 +24,7 @@ fn graph_with_snippet(name: &str, code: &str) -> MaterialGraph {
         .insert("code".to_string(), PinValue::String(code.to_string()));
     let output = graph.output_node().unwrap().id;
     graph.connect(node, "result", output, "base_color");
-    graph
+    (graph, node)
 }
 
 struct Fixture {
@@ -65,15 +66,16 @@ impl Fixture {
     }
 
     /// Write the graph, embedding the compiled artifact the way an editor
-    /// save does.
-    fn write(&mut self, code: &str) {
+    /// save does. Returns the snippet node's id.
+    fn write(&mut self, code: &str) -> u64 {
         let fs_path = self.dir.join(&self.rel);
-        let mut graph = graph_with_snippet("t", code);
+        let (mut graph, node) = graph_with_snippet("t", code);
         let (json, _) = renzora_shader::material::precompiled::save_compiled_and_serialize(
             &mut graph, &fs_path,
         )
         .unwrap();
         std::fs::write(&fs_path, json).unwrap();
+        node
     }
 
     /// Write the graph JSON with no embedded artifact, so the resolver runs
@@ -131,14 +133,12 @@ impl Fixture {
             .unwrap_or(0)
     }
 
-    fn problems(&self) -> Vec<(ProblemSeverity, String)> {
+    fn problems(&self) -> Vec<renzora::content_problems::ContentProblem> {
         self.app
             .world()
             .resource::<ContentProblems>()
             .get(&self.rel)
-            .iter()
-            .map(|p| (p.severity, p.message.clone()))
-            .collect()
+            .to_vec()
     }
 }
 
@@ -200,7 +200,7 @@ fn a_healthy_material_reports_nothing() {
 #[test]
 fn a_broken_material_is_reported_against_its_own_path() {
     let mut f = Fixture::new("broken");
-    f.write(BROKEN);
+    let node = f.write(BROKEN);
     f.spawn_user();
     f.pump();
 
@@ -210,11 +210,19 @@ fn a_broken_material_is_reported_against_its_own_path() {
         1,
         "expected exactly one report, got {problems:?}"
     );
-    assert_eq!(problems[0].0, ProblemSeverity::Error);
+    assert_eq!(problems[0].severity, ProblemSeverity::Error);
     assert!(
-        problems[0].1.contains("no_such_symbol"),
+        problems[0].message.contains("no_such_symbol"),
         "the report must name what is actually wrong, got {:?}",
-        problems[0].1
+        problems[0].message
+    );
+    // Attribution: the error belongs to the snippet's line and its node —
+    // what the graph editor marks.
+    assert!(problems[0].line.is_some(), "the report must carry a line");
+    assert_eq!(
+        problems[0].node_id,
+        Some(node),
+        "the report must land on the custom/code node"
     );
 }
 
@@ -271,7 +279,7 @@ fn one_broken_material_does_not_hide_a_healthy_one() {
 
     let other = "materials/other.material".to_string();
     let other_fs = f.dir.join(&other);
-    let mut graph = graph_with_snippet("other", GOOD);
+    let (mut graph, _) = graph_with_snippet("other", GOOD);
     let (json, _) = renzora_shader::material::precompiled::save_compiled_and_serialize(
         &mut graph, &other_fs,
     )
@@ -302,11 +310,11 @@ fn a_parameter_overflow_warns_and_a_repair_clears_it() {
         1,
         "one overflow, one row — got {problems:?}"
     );
-    assert_eq!(problems[0].0, ProblemSeverity::Warning);
+    assert_eq!(problems[0].severity, ProblemSeverity::Warning);
     assert!(
-        problems[0].1.contains("exceeds"),
+        problems[0].message.contains("exceeds"),
         "the row must say what overflowed, got {:?}",
-        problems[0].1
+        problems[0].message
     );
 
     f.write_raw(&graph_with_many_params("t", 2));

--- a/crates/renzora_shader/tests/material_problems.rs
+++ b/crates/renzora_shader/tests/material_problems.rs
@@ -1,0 +1,320 @@
+//! End-to-end: a broken material must be visible, and repairing it must clear.
+//! Drives the real `MaterialResolverPlugin` against files on disk, so what is
+//! asserted is what the editor's Problems panel shows.
+
+use bevy::prelude::*;
+use renzora::content_problems::{ContentProblems, ProblemSeverity};
+use renzora_shader::material::graph::{MaterialDomain, MaterialGraph, PinValue};
+use renzora_shader::material::material_ref::MaterialRef;
+use renzora_shader::material::resolver::{MaterialCache, MaterialResolved};
+
+/// A graph whose only node is a `custom/code` snippet driving `base_color`.
+///
+/// `custom/code` is the one node that still lets a user write arbitrary WGSL,
+/// which makes it the only way to author a graph that codegen accepts and the
+/// shader compiler rejects — exactly the case the panel exists for.
+fn graph_with_snippet(name: &str, code: &str) -> MaterialGraph {
+    let mut graph = MaterialGraph::new(name, MaterialDomain::Surface);
+    let node = graph.add_node("custom/code", [0.0, 0.0]);
+    graph
+        .get_node_mut(node)
+        .unwrap()
+        .input_values
+        .insert("code".to_string(), PinValue::String(code.to_string()));
+    let output = graph.output_node().unwrap().id;
+    graph.connect(node, "result", output, "base_color");
+    graph
+}
+
+struct Fixture {
+    app: App,
+    dir: std::path::PathBuf,
+    /// Project-relative, the key the panel reports under.
+    rel: String,
+}
+
+impl Fixture {
+    fn new(test_name: &str) -> Self {
+        let dir = std::env::temp_dir().join(format!(
+            "renzora_material_problems_{}_{}",
+            std::process::id(),
+            test_name
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(dir.join("materials")).unwrap();
+
+        let mut app = renzora_test_harness::headless_app_with(|app| {
+            // The resolver alone resolves nothing: a graph material needs the
+            // asset type and its pipeline registered before it can be built.
+            app.add_plugins((
+                renzora_shader::ShaderPlugin,
+                renzora_shader::material::runtime::GraphMaterialPlugin,
+                renzora_shader::material::resolver::MaterialResolverPlugin,
+            ));
+        });
+        app.insert_resource(renzora::CurrentProject {
+            path: dir.clone(),
+            config: Default::default(),
+        });
+
+        Self {
+            app,
+            dir,
+            rel: "materials/t.material".to_string(),
+        }
+    }
+
+    /// Write the graph, embedding the compiled artifact the way an editor
+    /// save does.
+    fn write(&mut self, code: &str) {
+        let fs_path = self.dir.join(&self.rel);
+        let mut graph = graph_with_snippet("t", code);
+        let (json, _) = renzora_shader::material::precompiled::save_compiled_and_serialize(
+            &mut graph, &fs_path,
+        )
+        .unwrap();
+        std::fs::write(&fs_path, json).unwrap();
+    }
+
+    /// Write the graph JSON with no embedded artifact, so the resolver runs
+    /// its live codegen path — the one that owns codegen warnings.
+    fn write_raw(&mut self, graph: &MaterialGraph) {
+        let fs_path = self.dir.join(&self.rel);
+        let json = serde_json::to_string_pretty(graph).unwrap();
+        std::fs::write(&fs_path, json).unwrap();
+    }
+
+    fn spawn_user(&mut self) {
+        self.app.world_mut().spawn(MaterialRef(self.rel.clone()));
+    }
+
+    /// Drop everything cached for the material and let the resolver run again —
+    /// the same two steps the editor performs after a save.
+    fn recompile(&mut self) {
+        let rel = self.rel.clone();
+        self.app
+            .world_mut()
+            .resource_mut::<MaterialCache>()
+            .invalidate(&rel);
+        let entities: Vec<Entity> = self
+            .app
+            .world_mut()
+            .query_filtered::<Entity, With<MaterialResolved>>()
+            .iter(self.app.world())
+            .collect();
+        for entity in entities {
+            self.app
+                .world_mut()
+                .entity_mut(entity)
+                .remove::<MaterialResolved>();
+        }
+        self.pump();
+    }
+
+    /// The validator is built from shader libraries that arrive as assets, so a
+    /// single frame is not always enough for the first resolve.
+    fn pump(&mut self) {
+        for _ in 0..8 {
+            self.app.update();
+        }
+    }
+
+    /// How many times the resolver has compiled the material — the number that
+    /// tells a settled material apart from one being rebuilt every frame.
+    fn compile_count(&self) -> u64 {
+        self.app
+            .world()
+            .resource::<renzora_shader::material::perf::MaterialPerfStats>()
+            .per_path
+            .get(&self.rel)
+            .map(|p| p.compile_count)
+            .unwrap_or(0)
+    }
+
+    fn problems(&self) -> Vec<(ProblemSeverity, String)> {
+        self.app
+            .world()
+            .resource::<ContentProblems>()
+            .get(&self.rel)
+            .iter()
+            .map(|p| (p.severity, p.message.clone()))
+            .collect()
+    }
+}
+
+impl Drop for Fixture {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.dir);
+    }
+}
+
+const GOOD: &str = "result = vec4<f32>(1.0, 0.0, 0.0, 1.0);";
+/// `no_such_symbol` parses as WGSL and passes codegen; only the shader compiler
+/// knows it is not a thing.
+const BROKEN: &str = "result = vec4<f32>(no_such_symbol, 0.0, 0.0, 1.0);";
+
+/// A graph with `params` uniquely-named `param/float` nodes, chained through
+/// `math/add` so the fast path cannot claim it and every parameter gets a
+/// slot. Past `MAX_PARAMETER_SLOTS` unique names, codegen warns.
+fn graph_with_many_params(name: &str, params: usize) -> MaterialGraph {
+    let mut graph = MaterialGraph::new(name, MaterialDomain::Surface);
+    let output = graph.output_node().unwrap().id;
+    // (node, its output pin) — param/float emits "value", math/add "result".
+    let mut acc: Option<(u64, &'static str)> = None;
+    for i in 0..params {
+        let param = graph.add_node("param/float", [i as f32 * 10.0, 0.0]);
+        graph
+            .get_node_mut(param)
+            .unwrap()
+            .input_values
+            .insert("name".to_string(), PinValue::String(format!("P{i}")));
+        acc = Some(match acc {
+            None => (param, "value"),
+            Some((prev, prev_pin)) => {
+                let add = graph.add_node("math/add", [i as f32 * 10.0, 50.0]);
+                graph.connect(prev, prev_pin, add, "a");
+                graph.connect(param, "value", add, "b");
+                (add, "result")
+            }
+        });
+    }
+    let (last, pin) = acc.unwrap();
+    graph.connect(last, pin, output, "base_color");
+    graph
+}
+
+#[test]
+fn a_healthy_material_reports_nothing() {
+    let mut f = Fixture::new("healthy");
+    f.write(GOOD);
+    f.spawn_user();
+    f.pump();
+
+    assert!(
+        f.problems().is_empty(),
+        "a material that compiles must report nothing, got {:?}",
+        f.problems()
+    );
+}
+
+#[test]
+fn a_broken_material_is_reported_against_its_own_path() {
+    let mut f = Fixture::new("broken");
+    f.write(BROKEN);
+    f.spawn_user();
+    f.pump();
+
+    let problems = f.problems();
+    assert_eq!(
+        problems.len(),
+        1,
+        "expected exactly one report, got {problems:?}"
+    );
+    assert_eq!(problems[0].0, ProblemSeverity::Error);
+    assert!(
+        problems[0].1.contains("no_such_symbol"),
+        "the report must name what is actually wrong, got {:?}",
+        problems[0].1
+    );
+}
+
+/// The one the user asked for: a repaired material must stop being reported.
+#[test]
+fn repairing_a_material_clears_its_report() {
+    let mut f = Fixture::new("repair");
+    f.write(BROKEN);
+    f.spawn_user();
+    f.pump();
+    assert!(!f.problems().is_empty(), "the break must register first");
+
+    f.write(GOOD);
+    f.recompile();
+
+    assert!(
+        f.problems().is_empty(),
+        "a repaired material must clear, still reporting {:?}",
+        f.problems()
+    );
+}
+
+/// A material nobody touched must not be recompiled.
+///
+/// Every compile mints a fresh `shader_uuid`, which is part of the pipeline
+/// key, so a material that recompiles on a timer gets a fresh pipeline on a
+/// timer — which is what a flickering surface looks like. This measures the
+/// resolver's half of that: whether the compile itself repeats.
+#[test]
+fn an_untouched_material_is_compiled_once() {
+    let mut f = Fixture::new("stable");
+    f.write(GOOD);
+    f.spawn_user();
+    f.pump();
+    assert_eq!(f.compile_count(), 1, "the first resolve must compile once");
+
+    for _ in 0..30 {
+        f.app.update();
+    }
+    assert_eq!(
+        f.compile_count(),
+        1,
+        "nothing changed, so nothing may be compiled again"
+    );
+}
+
+/// Breaking one material must not silence another, and must not report against
+/// the wrong file.
+#[test]
+fn one_broken_material_does_not_hide_a_healthy_one() {
+    let mut f = Fixture::new("two");
+    f.write(BROKEN);
+    f.spawn_user();
+
+    let other = "materials/other.material".to_string();
+    let other_fs = f.dir.join(&other);
+    let mut graph = graph_with_snippet("other", GOOD);
+    let (json, _) = renzora_shader::material::precompiled::save_compiled_and_serialize(
+        &mut graph, &other_fs,
+    )
+    .unwrap();
+    std::fs::write(&other_fs, json).unwrap();
+    f.app.world_mut().spawn(MaterialRef(other.clone()));
+    f.pump();
+
+    let all = f.app.world().resource::<ContentProblems>();
+    assert_eq!(all.get(&other).len(), 0, "the healthy material must be clean");
+    assert_eq!(all.error_count(), 1, "only the broken one may be reported");
+}
+
+/// The one warning codegen produces — more unique parameter names than the
+/// parameter buffer has slots — must reach the panel as a Warning row, and
+/// repairing the graph must clear it.
+#[test]
+fn a_parameter_overflow_warns_and_a_repair_clears_it() {
+    let mut f = Fixture::new("overflow");
+    let over = renzora_shader::material::codegen::MAX_PARAMETER_SLOTS + 1;
+    f.write_raw(&graph_with_many_params("t", over));
+    f.spawn_user();
+    f.pump();
+
+    let problems = f.problems();
+    assert_eq!(
+        problems.len(),
+        1,
+        "one overflow, one row — got {problems:?}"
+    );
+    assert_eq!(problems[0].0, ProblemSeverity::Warning);
+    assert!(
+        problems[0].1.contains("exceeds"),
+        "the row must say what overflowed, got {:?}",
+        problems[0].1
+    );
+
+    f.write_raw(&graph_with_many_params("t", 2));
+    f.recompile();
+
+    assert!(
+        f.problems().is_empty(),
+        "a repaired graph must clear its warning, still reporting {:?}",
+        f.problems()
+    );
+}

--- a/crates/renzora_shader/tests/material_problems.rs
+++ b/crates/renzora_shader/tests/material_problems.rs
@@ -36,6 +36,15 @@ struct Fixture {
 
 impl Fixture {
     fn new(test_name: &str) -> Self {
+        Self::with_session(test_name, true)
+    }
+
+    /// A fixture that is not an editor — what a shipped game looks like.
+    fn game(test_name: &str) -> Self {
+        Self::with_session(test_name, false)
+    }
+
+    fn with_session(test_name: &str, is_editor: bool) -> Self {
         let dir = std::env::temp_dir().join(format!(
             "renzora_material_problems_{}_{}",
             std::process::id(),
@@ -57,6 +66,10 @@ impl Fixture {
             path: dir.clone(),
             config: Default::default(),
         });
+        // The Problems-panel validator only runs in an editor session, so a
+        // fixture that asserts on its output has to be one. `renzora_runtime`
+        // inserts this in a real app; a headless test has no runtime setup.
+        app.insert_resource(renzora::EditorSession(is_editor));
 
         Self {
             app,
@@ -193,6 +206,26 @@ fn a_healthy_material_reports_nothing() {
     assert!(
         f.problems().is_empty(),
         "a material that compiles must report nothing, got {:?}",
+        f.problems()
+    );
+}
+
+/// A shipped game must not run the validator, whatever the `editor` feature
+/// says. `xtask` builds both executables with one `cargo build --workspace`,
+/// so cargo unifies `renzora_shader/editor` on from `renzora_material_editor`
+/// and the runtime binary is compiled with it too — the feature cannot be the
+/// gate. `EditorSession` is, and this is the test that says so: same broken
+/// material as the test below, same asserts, one resource different.
+#[test]
+fn a_game_session_never_validates() {
+    let mut f = Fixture::game("game_session");
+    f.write(BROKEN);
+    f.spawn_user();
+    f.pump();
+
+    assert!(
+        f.problems().is_empty(),
+        "a game reported material problems it has no panel for: {:?}",
         f.problems()
     );
 }

--- a/crates/renzora_shader_editor/src/hot_reload.rs
+++ b/crates/renzora_shader_editor/src/hot_reload.rs
@@ -23,7 +23,7 @@ use bevy::prelude::*;
 use crossbeam_channel::{unbounded, Receiver};
 use notify_debouncer_full::{
     new_debouncer,
-    notify::{RecommendedWatcher, RecursiveMode},
+    notify::{event::ModifyKind, EventKind, RecommendedWatcher, RecursiveMode},
     DebounceEventResult, Debouncer, RecommendedCache,
 };
 
@@ -105,6 +105,24 @@ fn ensure_watcher_for_current_project(
     commands.insert_resource(WgslHotReload::install(project.path.clone()));
 }
 
+/// Whether an event says the file's *content* moved, as opposed to somebody
+/// having looked at it.
+///
+/// inotify reports opens, reads and closes too, and the resolver reads every
+/// `.wgsl` it re-resolves — so treating an access as an edit makes the watcher
+/// feed itself: invalidate, re-resolve, read, invalidate. Measured at 80
+/// self-inflicted reloads in 20 seconds on a project nobody was editing, one
+/// per debounce window, each one a frame with no pipeline to draw with.
+///
+/// `Any` stays in because it is what a backend emits when it cannot say more
+/// precisely, and dropping it silently disables hot-reload there.
+pub fn is_content_change(kind: &EventKind) -> bool {
+    !matches!(
+        kind,
+        EventKind::Access(_) | EventKind::Other | EventKind::Modify(ModifyKind::Metadata(_))
+    )
+}
+
 /// Drain pending file events and invalidate the resolver cache for any changed
 /// `.wgsl`.
 fn drain_wgsl_events(
@@ -119,6 +137,9 @@ fn drain_wgsl_events(
         match result {
             Ok(events) => {
                 for event in events {
+                    if !is_content_change(&event.kind) {
+                        continue;
+                    }
                     for path in &event.paths {
                         invalidate_for_wgsl(
                             path,

--- a/crates/renzora_shader_editor/src/lib.rs
+++ b/crates/renzora_shader_editor/src/lib.rs
@@ -1,7 +1,7 @@
 //! Shader Editor — code-based shader authoring with multi-language support.
 
 mod code_panel;
-mod hot_reload;
+pub mod hot_reload;
 mod native_compiler_log;
 mod native_preview;
 mod native_properties;

--- a/crates/renzora_shader_editor/tests/hot_reload_events.rs
+++ b/crates/renzora_shader_editor/tests/hot_reload_events.rs
@@ -87,11 +87,17 @@ fn reading_a_watched_file_is_not_a_change() {
     );
     // Without this the test proves nothing: it also passes on a platform
     // that reports no read events at all, while the loop it guards against
-    // lives on.
+    // lives on. Only inotify guarantees those events — macOS/Windows
+    // backends may report none, and there the filter genuinely went
+    // untested rather than failing. CI runs Linux, so the strict check
+    // still has teeth where it runs.
+    #[cfg(target_os = "linux")]
     assert!(
         ignored > 0,
         "this platform reported no access events, so the filter went untested"
     );
+    #[cfg(not(target_os = "linux"))]
+    let _ = ignored;
 }
 
 #[test]

--- a/crates/renzora_shader_editor/tests/hot_reload_events.rs
+++ b/crates/renzora_shader_editor/tests/hot_reload_events.rs
@@ -1,0 +1,108 @@
+//! Reading a watched `.wgsl` must not look like an edit — the resolver reads
+//! every file it re-resolves, so an access that counts as a change never stops.
+
+use std::time::{Duration, Instant};
+
+use notify_debouncer_full::{
+    new_debouncer,
+    notify::{RecommendedWatcher, RecursiveMode},
+    DebounceEventResult, Debouncer, RecommendedCache,
+};
+use renzora_shader_editor::hot_reload::is_content_change;
+
+const DEBOUNCE: Duration = Duration::from_millis(200);
+
+struct Watched {
+    dir: std::path::PathBuf,
+    rx: std::sync::mpsc::Receiver<DebounceEventResult>,
+    _debouncer: Debouncer<RecommendedWatcher, RecommendedCache>,
+}
+
+fn watch(test_name: &str) -> Watched {
+    let dir = std::env::temp_dir().join(format!(
+        "renzora_hot_reload_{}_{test_name}",
+        std::process::id()
+    ));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(dir.join("m.wgsl"), "// original\n").unwrap();
+
+    let (tx, rx) = std::sync::mpsc::channel();
+    let mut debouncer = new_debouncer(DEBOUNCE, None, move |result| {
+        let _ = tx.send(result);
+    })
+    .unwrap();
+    debouncer.watch(&dir, RecursiveMode::Recursive).unwrap();
+    // The watch is registered on a background thread; an event raised before it
+    // is in place is not delivered.
+    std::thread::sleep(DEBOUNCE * 2);
+    Watched {
+        dir,
+        rx,
+        _debouncer: debouncer,
+    }
+}
+
+impl Watched {
+    /// Everything the watcher delivered within `window`, split by whether the
+    /// filter calls it a content change.
+    fn drain(&self, window: Duration) -> (Vec<std::path::PathBuf>, usize) {
+        let deadline = Instant::now() + window;
+        let (mut changed, mut ignored) = (Vec::new(), 0);
+        while let Some(left) = deadline.checked_duration_since(Instant::now()) {
+            let Ok(Ok(events)) = self.rx.recv_timeout(left) else {
+                continue;
+            };
+            for event in events {
+                if is_content_change(&event.kind) {
+                    changed.extend(event.paths.iter().cloned());
+                } else {
+                    ignored += 1;
+                }
+            }
+        }
+        (changed, ignored)
+    }
+}
+
+impl Drop for Watched {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.dir);
+    }
+}
+
+#[test]
+fn reading_a_watched_file_is_not_a_change() {
+    let w = watch("read");
+    let path = w.dir.join("m.wgsl");
+    for _ in 0..5 {
+        let _ = std::fs::read_to_string(&path).unwrap();
+        std::thread::sleep(DEBOUNCE / 2);
+    }
+
+    let (changed, ignored) = w.drain(DEBOUNCE * 4);
+    assert!(
+        changed.is_empty(),
+        "reading a file must not register as an edit, got {changed:?}"
+    );
+    // Without this the test proves nothing: it also passes on a platform
+    // that reports no read events at all, while the loop it guards against
+    // lives on.
+    assert!(
+        ignored > 0,
+        "this platform reported no access events, so the filter went untested"
+    );
+}
+
+#[test]
+fn writing_a_watched_file_is_a_change() {
+    let w = watch("write");
+    let path = w.dir.join("m.wgsl");
+    std::fs::write(&path, "// edited\n").unwrap();
+
+    let (changed, _) = w.drain(DEBOUNCE * 6);
+    assert!(
+        changed.contains(&path),
+        "an actual edit must still come through, got {changed:?}"
+    );
+}

--- a/crates/renzora_terrain/Cargo.toml
+++ b/crates/renzora_terrain/Cargo.toml
@@ -18,11 +18,5 @@ renzora_physics = { path = "../renzora_physics", default-features = false }
 # `GrassInstance` has to be `Pod` for `RawBufferVec` to accept it.
 bytemuck = { version = "1", features = ["derive"] }
 
-[dev-dependencies]
-# Compile-checks `grass.wgsl` (see `foliage::shader_test`). Bevy compiles shaders
-# at run time, so a hand-written pipeline's WGSL is otherwise only validated by a
-# GPU nobody has in CI. Pinned to the naga wgpu itself uses.
-naga = "29"
-
 [lints]
 workspace = true

--- a/crates/renzora_terrain/src/foliage/shader_test.rs
+++ b/crates/renzora_terrain/src/foliage/shader_test.rs
@@ -12,8 +12,6 @@
 //! a mismatch between the WGSL's bindings and the Rust pipeline's bind group
 //! layout, since only the driver sees both.
 
-use naga::valid::{Capabilities, ValidationFlags, Validator};
-
 /// Bevy's `bevy_render::view::View`, cut down to the fields `grass.wgsl` uses.
 ///
 /// The shader's `#import` is Bevy preprocessor syntax that naga doesn't speak,
@@ -41,17 +39,7 @@ fn preprocessed_grass_shader() -> String {
 #[test]
 fn grass_shader_parses_and_validates() {
     let source = preprocessed_grass_shader();
-    let module = match naga::front::wgsl::parse_str(&source) {
-        Ok(module) => module,
-        Err(err) => panic!(
-            "grass.wgsl failed to parse:\n{}",
-            err.emit_to_string(&source)
-        ),
-    };
-    let mut validator = Validator::new(ValidationFlags::all(), Capabilities::all());
-    if let Err(err) = validator.validate(&module) {
-        panic!("grass.wgsl failed validation:\n{err:?}");
-    }
+    renzora::wgsl::check(&source).unwrap_or_else(|err| panic!("grass.wgsl: {err}"));
 }
 
 /// The pipeline names these entry points explicitly, so a rename in either place
@@ -59,7 +47,7 @@ fn grass_shader_parses_and_validates() {
 #[test]
 fn grass_shader_has_the_entry_points_the_pipeline_asks_for() {
     let source = preprocessed_grass_shader();
-    let module = naga::front::wgsl::parse_str(&source).expect("grass.wgsl should parse");
+    let module = renzora::wgsl::parse(&source).expect("grass.wgsl should parse");
     let names: Vec<&str> = module
         .entry_points
         .iter()

--- a/crates/renzora_test_harness/src/lib.rs
+++ b/crates/renzora_test_harness/src/lib.rs
@@ -104,6 +104,20 @@ pub fn headless_app() -> App {
     app
 }
 
+/// [`headless_app`] with a chance to add plugins first.
+///
+/// `headless_app` calls `finish()` before it returns, and Bevy refuses plugins
+/// after that — so a test that needs an engine plugin under test has to get in
+/// beforehand. `build` runs with the base plugins added and `finish()` still
+/// pending.
+pub fn headless_app_with(build: impl FnOnce(&mut App)) -> App {
+    let mut app = App::new();
+    app.add_plugins(headless_plugins(None));
+    build(&mut app);
+    app.finish();
+    app
+}
+
 /// [`headless_app`] with the asset root pointed somewhere specific.
 ///
 /// Bevy resolves the default asset root relative to the *current directory*,

--- a/crates/renzora_water/Cargo.toml
+++ b/crates/renzora_water/Cargo.toml
@@ -21,12 +21,10 @@ serde = { version = "1", features = ["derive"] }
 avian3d = { version = "0.7", default-features = false, features = ["3d", "f32"], optional = true }
 
 [dev-dependencies]
-# Compiles the WGSL compute kernels in a unit test. Without a GPU in CI (and
-# with shader errors otherwise only surfacing as a silent pipeline failure at
-# runtime), this is the only place a typo in the simulation shaders gets caught.
-# Same version wgpu itself uses, so the validation matches what the engine will
-# do at load time.
-naga = { version = "29", features = ["wgsl-in"] }
+# Compiles the WGSL compute kernels in a unit test via `renzora::wgsl`. Without
+# a GPU in CI (and with shader errors otherwise only surfacing as a silent
+# pipeline failure at runtime), that test is the only place a typo in the
+# simulation shaders gets caught.
 
 [lints]
 workspace = true

--- a/crates/renzora_water/Cargo.toml
+++ b/crates/renzora_water/Cargo.toml
@@ -20,11 +20,5 @@ renzora = { path = "../renzora", default-features = false }
 serde = { version = "1", features = ["derive"] }
 avian3d = { version = "0.7", default-features = false, features = ["3d", "f32"], optional = true }
 
-[dev-dependencies]
-# Compiles the WGSL compute kernels in a unit test via `renzora::wgsl`. Without
-# a GPU in CI (and with shader errors otherwise only surfacing as a silent
-# pipeline failure at runtime), that test is the only place a typo in the
-# simulation shaders gets caught.
-
 [lints]
 workspace = true

--- a/crates/renzora_water/src/material.rs
+++ b/crates/renzora_water/src/material.rs
@@ -201,15 +201,7 @@ fn stub_apply_pbr_lighting(input: PbrInput) -> vec4<f32> { return input.material
             .replace("pbr_input_new", "stub_pbr_input_new");
         let combined = format!("{STUBS}\n{body}");
 
-        let module = naga::front::wgsl::parse_str(&combined)
-            .unwrap_or_else(|err| panic!("water.wgsl: {}", err.emit_to_string(&combined)));
-        let mut validator = naga::valid::Validator::new(
-            naga::valid::ValidationFlags::all(),
-            naga::valid::Capabilities::all(),
-        );
-        if let Err(err) = validator.validate(&module) {
-            panic!("water.wgsl: {}", err.emit_to_string(&combined));
-        }
+        renzora::wgsl::check(&combined).unwrap_or_else(|err| panic!("water.wgsl: {err}"));
     }
 
     #[test]

--- a/crates/renzora_water/src/sim.rs
+++ b/crates/renzora_water/src/sim.rs
@@ -604,15 +604,7 @@ mod tests {
     /// shows up only as a pipeline that never becomes ready — the ocean simply
     /// stays flat, with the reason buried in the log.
     fn validate(name: &str, source: &str) {
-        let module = naga::front::wgsl::parse_str(source)
-            .unwrap_or_else(|err| panic!("{name}: {}", err.emit_to_string(source)));
-        let mut validator = naga::valid::Validator::new(
-            naga::valid::ValidationFlags::all(),
-            naga::valid::Capabilities::all(),
-        );
-        if let Err(err) = validator.validate(&module) {
-            panic!("{name}: {}", err.emit_to_string(source));
-        }
+        renzora::wgsl::check(source).unwrap_or_else(|err| panic!("{name}: {err}"));
     }
 
     #[test]

--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -111,7 +111,7 @@ RUN if [ "$(uname -m)" = "aarch64" ]; then HOSTRUST=aarch64-unknown-linux-gnu; e
 # section (cross-gcc linker) is appended by docker/linux/Dockerfile.
 [target.${HOSTRUST}]
 linker = "clang"
-rustflags = ["-C", "link-arg=-fuse-ld=/usr/bin/mold"]
+rustflags = ["-C", "link-arg=-fuse-ld=mold"]
 TOML
 
 # ── UPX ──────────────────────────────────────────────────────────────────────

--- a/docker/linux/Dockerfile
+++ b/docker/linux/Dockerfile
@@ -83,8 +83,8 @@ RUN set -eux; \
 # NATIVE arch, which is correct).
 #
 # The linker is a WRAPPER, not the cross-gcc directly, because the repo's Linux
-# `target.rustflags` pass `-fuse-ld=/usr/bin/mold` as an absolute PATH — clang
-# accepts that, GCC rejects it ("unrecognized command-line option"). We can't
+# `target.rustflags` pass `-fuse-ld=mold`, which aims the NATIVE mold at a
+# foreign target. We can't
 # drop it via CARGO_TARGET_<triple>_RUSTFLAGS: unlike LINKER, that env does NOT
 # override a config file's `target.rustflags` (a cargo precedence quirk — config
 # wins), so the flag always reaches the linker. The wrapper strips exactly that
@@ -93,7 +93,7 @@ RUN set -eux; \
 RUN XGNU=$(cat /etc/renzora-linux-cross-gnu); XRUST=$(cat /etc/renzora-linux-cross-triple); \
     XRUST_US=$(echo "$XRUST" | tr - _); \
     XRUST_ENV=$(echo "$XRUST" | tr 'a-z-' 'A-Z_'); \
-    printf '#!/bin/bash\n# Strip three args before handing them to the cross-gcc:\n#   -fuse-ld=/usr/bin/mold    clang accepts an absolute path here, GCC does not.\n#   -fuse-ld=lld, -B*/gcc-ld  rustc aims these at its own bundled rust-lld in the\n#     HOST sysroot (.../x86_64-unknown-linux-gnu/bin/gcc-ld). Following them links\n#     an aarch64 target with an x86_64-flavoured lld, which then rejects the\n#     aarch64-only flag the cross-gcc driver adds:\n#       rust-lld: error: --fix-cortex-a53-843419 is only supported on AArch64\n#     That is what cost every release its linux-arm64 slice. The lane is\n#     best-effort, so it was a WARN and the build still went green.\nargs=()\nfor a in "$@"; do\n  case "$a" in\n    -fuse-ld=/usr/bin/mold|-fuse-ld=lld) continue ;;\n    -B*/gcc-ld) continue ;;\n  esac\n  args+=("$a")\ndone\nexec %s-gcc "${args[@]}"\n' "$XGNU" \
+    printf '#!/bin/bash\n# Strip three args before handing them to the cross-gcc:\n#   -fuse-ld=mold             the native mold, aimed at a foreign target.\n#   -fuse-ld=lld, -B*/gcc-ld  rustc aims these at its own bundled rust-lld in the\n#     HOST sysroot (.../x86_64-unknown-linux-gnu/bin/gcc-ld). Following them links\n#     an aarch64 target with an x86_64-flavoured lld, which then rejects the\n#     aarch64-only flag the cross-gcc driver adds:\n#       rust-lld: error: --fix-cortex-a53-843419 is only supported on AArch64\n#     That is what cost every release its linux-arm64 slice. The lane is\n#     best-effort, so it was a WARN and the build still went green.\nargs=()\nfor a in "$@"; do\n  case "$a" in\n    -fuse-ld=mold|-fuse-ld=/usr/bin/mold|-fuse-ld=lld) continue ;;\n    -B*/gcc-ld) continue ;;\n  esac\n  args+=("$a")\ndone\nexec %s-gcc "${args[@]}"\n' "$XGNU" \
         > /usr/local/bin/renzora-cross-linker && \
     chmod +x /usr/local/bin/renzora-cross-linker && \
     { \

--- a/docs/r1-alpha7/api/material-node-reference.md
+++ b/docs/r1-alpha7/api/material-node-reference.md
@@ -29,9 +29,10 @@ A few rules apply everywhere:
 - **Pin types coerce automatically.** `Float`, `Vec2`, `Vec3`, `Vec4`, and `Color`
   are freely inter-connectable. Wiring a scalar into a vector copies it across every
   lane; wiring a wider vector into a narrower pin takes the leading components. So a
-  `math/multiply` works on floats *or* colors with no extra nodes. `Bool` sits
-  outside that family. Where a graph wires one into a numeric pin, the compiler
-  casts it, turning `true` into `1.0` and `false` into `0.0`.
+  `math/multiply` works on floats *or* colors with no extra nodes. `Bool` is the
+  exception: it is not part of the numeric family, so the editor refuses to wire it
+  into a numeric pin. Graphs saved before that gate still compile — the compiler
+  casts, turning `true` into `1.0` and `false` into `0.0`.
 - **Unconnected UV inputs default to the mesh UVs.** Texture and pattern nodes that
   take a `uv` pin fall back to the mesh's UV attribute (`mat_uv`) when you leave it
   empty, so the simplest possible graph still works.

--- a/docs/r1-alpha7/api/material-node-reference.md
+++ b/docs/r1-alpha7/api/material-node-reference.md
@@ -10,7 +10,12 @@ This page is the per-node companion to the [Material API](/docs/r1-alpha7/api/ma
 
 All nodes live in `renzora_shader` — declared in `material/nodes.rs` (`ALL_NODES`)
 and compiled to WGSL in `material/codegen.rs`. There are **13 categories** and
-roughly **124 node types**.
+**159 node types**. Every generated fragment shader — one synthetic graph per
+node type, plus every `.material` shipped under `assets/materials/` — is
+compiled in the test suite the way the engine compiles it: naga_oil's composer
+over bevy_pbr's own shader sources, then naga. Imports resolve to the real
+thing, so a node whose codegen drifts invalid is a CI failure rather than a
+silent runtime fallback.
 
 ## How to read this page
 
@@ -24,7 +29,9 @@ A few rules apply everywhere:
 - **Pin types coerce automatically.** `Float`, `Vec2`, `Vec3`, `Vec4`, and `Color`
   are freely inter-connectable. Wiring a scalar into a vector copies it across every
   lane; wiring a wider vector into a narrower pin takes the leading components. So a
-  `math/multiply` works on floats *or* colors with no extra nodes.
+  `math/multiply` works on floats *or* colors with no extra nodes. `Bool` sits
+  outside that family. Where a graph wires one into a numeric pin, the compiler
+  casts it, turning `true` into `1.0` and `false` into `0.0`.
 - **Unconnected UV inputs default to the mesh UVs.** Texture and pattern nodes that
   take a `uv` pin fall back to the mesh's UV attribute (`mat_uv`) when you leave it
   empty, so the simplest possible graph still works.
@@ -62,8 +69,9 @@ noted; they're where data *enters* the graph.
 
 Named graph-boundary inputs. The `name` pin is the identifier a **material
 instance** or a `MaterialOverrides` component overrides by name; the `default` pin
-is the value baked into the master shader. A graph may declare up to **32**
-parameters. Header color: purple.
+is the value baked into the master shader. A graph can declare up to **32**
+parameters. Past the cap the extra names alias the last slot, and the Problems
+panel shows a warning. Header color: purple.
 
 | Node | Inputs | Outputs | What it does |
 |------|--------|---------|--------------|

--- a/docs/r1-alpha7/editor/materials.md
+++ b/docs/r1-alpha7/editor/materials.md
@@ -17,6 +17,8 @@ Your changes save automatically as you work, and the mesh updates live so you ca
 
 You build a material by dragging nodes out of the category menu and **wiring them together**: drag from a node's output dot (on its right edge) into another node's input dot (on its left edge). Anything you leave unconnected just uses the value typed into the node.
 
+Wire dots are coloured by pin type, and any numeric types interconnect freely — a `Vec2` can feed a `Color` pin, a `Float` can feed a `Vec3`, and so on (the compiler inserts the right conversion). A wire between two *different* pin colours draws as a gradient from the source colour to the target colour, so you can see at a glance where a conversion is happening. Only genuinely incompatible pins (bool, texture, sampler) refuse the connection outright.
+
 ![A material node graph: two Sample Texture nodes and a Sample Normal Map node wired by colored cables into the Surface Output node on the right](/assets/previews/material_graph.png)
 
 In the shot above, a color texture feeds the **Base Color** pin, another texture drives **Metallic** and **Roughness**, and a normal map plugs into **Normal** — all flowing into the **Surface Output** node on the right. That output node is the heart of every material.

--- a/docs/r1-alpha7/editor/materials.md
+++ b/docs/r1-alpha7/editor/materials.md
@@ -265,12 +265,13 @@ Only a **write** counts. Opening a `.wgsl`, reading it, or touching its timestam
 
 ## When a material fails to compile
 
-A graph can be well-formed and still produce WGSL the shader compiler rejects — most easily through a **Custom Code** node, whose contents nothing checks until the compiler sees them. The material then falls back to a plain surface in the viewport, and the compiler's errors show up in two places:
+A graph can be well-formed and still produce WGSL the shader compiler rejects — most easily through a **Custom Code** node, whose contents nothing checks until the compiler sees them. The material then falls back to a plain surface in the viewport, and the compiler's errors show up in three places:
 
+- **On the node itself.** The offending node gets a red warning icon in its title bar. Hover the node for the compiler's message.
 - **The Problems panel**, as a row per distinct error, listed against the `.material` file it came from. Click a row to jump to that file if you have it open.
 - **The console**, once per compile — not once per frame, so a broken material does not flood the log.
 
-Both clear on their own as soon as the material compiles again. There is nothing to dismiss and no restart involved. Fix the graph, press **Apply**, and the row disappears.
+All three clear on their own as soon as the material compiles again. There is nothing to dismiss and no restart involved. Fix the graph, press **Apply**, and the row and the icon disappear.
 
 Some errors appear only under certain conditions — a mesh with vertex colors, or a camera with an environment map. Those rows carry a `[defines: …]` prefix naming the configurations that fail, because the configuration is part of what is wrong. An error with no prefix fails everywhere.
 

--- a/docs/r1-alpha7/editor/materials.md
+++ b/docs/r1-alpha7/editor/materials.md
@@ -19,6 +19,8 @@ You build a material by dragging nodes out of the category menu and **wiring the
 
 Wire dots are coloured by pin type, and any numeric types interconnect freely — a `Vec2` can feed a `Color` pin, a `Float` can feed a `Vec3`, and so on (the compiler inserts the right conversion). A wire between two *different* pin colours draws as a gradient from the source colour to the target colour, so you can see at a glance where a conversion is happening. Only genuinely incompatible pins (bool, texture, sampler) refuse the connection outright.
 
+**Math nodes adapt to their wires.** A Math node starts out as a plain `Float` node, but wire a `Vec4` into one of its inputs and the whole node follows: the other inputs and the result become `Vec4` too, the pin dots recolour, and any narrower wire feeding it is widened automatically. The widest wire wins (`Float` < `Vec2` < `Vec3` < `Vec4`), unplugging it drops the node back down, and a wide *consumer* on the result never widens the inputs — adaptation only flows from what feeds the node. One exception: `lerp`'s **T** pin always stays a `Float`, because a blend factor is a scalar.
+
 ![A material node graph: two Sample Texture nodes and a Sample Normal Map node wired by colored cables into the Surface Output node on the right](/assets/previews/material_graph.png)
 
 In the shot above, a color texture feeds the **Base Color** pin, another texture drives **Metallic** and **Roughness**, and a normal map plugs into **Normal** — all flowing into the **Surface Output** node on the right. That output node is the heart of every material.

--- a/docs/r1-alpha7/editor/materials.md
+++ b/docs/r1-alpha7/editor/materials.md
@@ -259,6 +259,19 @@ If you want to write shader code directly, that's a **standalone shader**, not a
 
 > Materials written by an older version — the ones with a `.wgsl` and `.wgsl.meta` next to them — still load exactly as before. The next time you save one, its shader moves inside the `.material` and the two stale files are removed for you.
 
+Only a **write** counts. Opening a `.wgsl`, reading it, or touching its timestamp does not reload the material. The editor itself has the file open, so a reload triggered by a read re-triggers itself.
+
+## When a material fails to compile
+
+A graph can be well-formed and still produce WGSL the shader compiler rejects — most easily through a **Custom Code** node, whose contents nothing checks until the compiler sees them. The material then falls back to a plain surface in the viewport, and the compiler's errors show up in two places:
+
+- **The Problems panel**, as a row per distinct error, listed against the `.material` file it came from. Click a row to jump to that file if you have it open.
+- **The console**, once per compile — not once per frame, so a broken material does not flood the log.
+
+Both clear on their own as soon as the material compiles again. There is nothing to dismiss and no restart involved. Fix the graph, press **Apply**, and the row disappears.
+
+Some errors appear only under certain conditions — a mesh with vertex colors, or a camera with an environment map. Those rows carry a `[defines: …]` prefix naming the configurations that fail, because the configuration is part of what is wrong. An error with no prefix fails everywhere.
+
 ## Tips
 
 - **Keep roughness above ~0.05.** Perfectly smooth surfaces can sparkle with artifacts.

--- a/docs/r1-alpha7/editor/materials.md
+++ b/docs/r1-alpha7/editor/materials.md
@@ -9,7 +9,7 @@ Switch to the **Materials** workspace in the editor, then pick what you want to 
 - **Click a mesh in the viewport.** Its material loads straight into the graph, ready to tweak.
 - **Or double-click a `.material` file** in the asset browser to open it on its own tab.
 
-Your changes save automatically as you work, and the mesh updates live so you can see the result right away. There's also an **Apply** button in the panel toolbar if you want to force a save.
+Your changes save automatically as you work, and the mesh updates live so you can see the result right away. Press **Ctrl+S** (or the **Apply** button in the panel toolbar) to force a save.
 
 > Materials are saved as `.material` files (plain JSON). When you import a 3D model, every material on it is written out as a `.material` next to the model automatically — so you can open and edit any imported look as a node graph.
 

--- a/docs/r1-alpha7/editor/shortcuts.md
+++ b/docs/r1-alpha7/editor/shortcuts.md
@@ -151,7 +151,7 @@ These act on the selected row, and only while the Hierarchy is the panel you las
 |---|---|
 | `Ctrl+N` | New scene |
 | `Ctrl+O` | Open scene |
-| `Ctrl+S` | Save scene |
+| `Ctrl+S` | Save scene; also saves the open material graph when the Material Graph panel is a visible tab (`material_graph.save`, rebindable) |
 | `Ctrl+Shift+S` | Save scene as |
 | `Ctrl+,` | Open Settings |
 

--- a/docs/r1-alpha7/extending/material-nodes.md
+++ b/docs/r1-alpha7/extending/material-nodes.md
@@ -57,6 +57,8 @@ A node only stores *overrides* for its input pins in `input_values`. Pins with n
 
 All numeric/vector/color types are **freely inter-convertible at the graph level** — `PinType::compatible` allows the wire and `PinType::cast_expr` inserts the WGSL coercion (widening copies the scalar into every lane; narrowing takes the leading components). `String` pins only connect to other strings.
 
+For `math/*` nodes the declared `Float` is only the starting point: their pins are **dynamic**. A math node latches to the widest rank wired into any of its inputs (`Float` < `Vec2` < `Vec3` < `Vec4` = `Color`), and every dynamic pin — the other inputs and the result — adopts that rank; narrower sources are widened at the pin by `cast_expr`. A wide *consumer* on the result never widens the inputs, and `math/lerp`'s `t` stays `Float` (WGSL's `mix` takes a scalar blend factor). Resolution is a pure function of the graph (`resolve_math_ranks` in `material::graph`), so nothing is serialized. When a node's codegen guards against a scalar (`max({b}, 0.000001)`), emit the guard at the latched rank — a bare scalar under a latched vector node is a naga type error. `Ctx::guard_lit` splats the literal.
+
 ## Node types and categories
 
 Every node is identified by a namespaced `node_type` string (e.g. `"math/add"`, `"texture/sample"`, `"output/surface"`). `renzora_shader` ships over 150 built-in nodes across these categories (`nodes::categories()`):


### PR DESCRIPTION
## Summary

One theme: a material's shader should be wrong visibly, not silently — and its math
nodes should not be scalar-only:

1. **Validate every generated shader.** The test suite compiles each shipped
   `.material` and one synthetic graph per node type through the same path the engine
   uses — naga_oil's composer over bevy_pbr's real shader libraries, then naga, once
   per pipeline-define configuration. At runtime the resolver validates the WGSL each
   graph material binds and reports what the compiler rejects into the Problems panel.
2. **Wire by compatibility, not colour.** Cable drops used to be filtered by pin
   colour, so only identical types connected and a `Vec2` could not feed a `Color`
   pin — even though the compiler has always coerced pin types. Ports now carry a
   compatibility group derived from `PinType::compatible`; colour is purely visual,
   and a wire between two colours draws as a gradient, marking where a conversion
   happens. Incompatible pins (bool, texture, sampler) are refused outright.
3. **Stop the `.wgsl` watcher reloading on its own reads.** inotify reports opens,
   reads and closes, and the resolver reads every file it re-resolves, so each reload
   triggered the next: 80 self-inflicted reloads in 20 seconds on an idle project,
   each a frame with no pipeline to draw with.
4. **One WGSL validation seam.** Four crates re-rolled the same
   parse + `Validator::new(all, all)`; `renzora::wgsl` owns it now.
5. **Attribute compile errors to graph nodes.** Codegen records which node authored
   which lines, the validator decodes the compiler's spans back through that map, and
   the error lands on the node itself — red warning icon, hover tooltip with the
   compiler's message. Shader compilation is logged to the Console panel, which
   `warn!` never reached.
6. **Vectorize the math nodes.** A `math/*` node's pins stop being hard-coded
   `Float`: the node latches to the widest rank wired into any input, and sibling
   inputs, the result, pin colours and inline editors all follow.

## Changes

### Shader validation & the Problems panel

- `material/validate.rs` — a `naga_oil::compose::Composer` loaded from the app's own
  `Assets<Shader>`, with the defines `PipelineCache` and `MeshPipeline` set. bevy_pbr's
  shader libraries are ordinary assets, so a headless app with no adapter has all of
  them; `#import` resolves to the real source rather than a stand-in.
- `renzora::content_problems` — the per-file store behind the Problems panel, in the
  contract crate because the producer (the material resolver) and the reader (the code
  editor) must agree on one definition. One row per distinct compiler message, with a
  `[defines: …]` prefix when only some pipeline configurations fail. Producers own a
  severity each — the validator owns errors, compile sites own warnings — and
  `set_severity` replaces one without clobbering the other.
- Bugs the suite caught: abstract float literals, pin defaults ignoring their declared
  type, `param/bool` into float pins, triplanar weight redeclaration and swizzle
  binding, and `scene/env_map_sample` / `scene/env_map_reflect` reading a binding
  bevy_pbr only creates under `ENVIRONMENT_MAP` — which broke those materials for any
  camera without an environment map light.
- Codegen warnings finally reach a user: the parameter-slot-overflow warning is logged
  once per compile and reported into the panel as a Warning row, from both compile
  sites — the material editor's save and the resolver's live-codegen fallback. The
  panel already rendered warnings; this is the first producer.

### Pin compatibility

- `renzora_ember`'s node-graph widget: ports carry a compatibility group; colour stays
  per-type and purely visual. A wire between two colours draws as a gradient
  (`cable.wgsl`). Blueprint and particle pins are untyped and share group 0, so their
  behaviour is unchanged.
- The material editor rejects an incompatible connection outright, not just its drop
  target. `Bool` stays outside the numeric family in the UI; graphs saved before the
  gate still compile through the compiler's `bool → float` cast.

### Watcher fix

- `hot_reload.rs` — the event drain filters to kinds that move content. `Access`,
  `Other`, and metadata-only `Modify` events no longer invalidate the resolver cache.

### `renzora::wgsl`

- New module: `parse`, `validate` (flags and capabilities decided once), `check` for
  pass/fail tests. `renzora_water`, `renzora_clouds`, `renzora_terrain` delete their
  local copies and their naga dependencies (water's was a main dependency used only in
  tests). `plugin_bridge` keeps its layouter and binding check; only the parse moves.
  The material validator's post-compose naga step goes through the same function.

### Error attribution

- Codegen tags every emitted line with the node being generated (save/restored
  around recursion) and resolves those into absolute
  `(node, first line, last line)` ranges on `CompileResult.node_lines` — PbrInput
  mutation lines included, attributed to the pin's feeding node. The map persists
  in the compiled artifact's meta, embedded in the `.material` itself
  (`#[serde(default)]`, old files load fine), so the precompiled path attributes
  identically to live codegen; the legacy `.wgsl.meta` sidecar is still read where
  one exists.
- The validator decodes naga_oil's spans before stringifying: the preprocessor is
  line-preserving and the `SPAN_SHIFT` module tag separates generated code from
  bevy_pbr libraries, so user errors get a line and engine errors correctly get
  none. `ContentProblem` carries `line` and `node_id`; the resolver threads the
  map through `MaterialCache`.
- Latent bug this exposed and fixed: module-prelude chunks carried no trailing
  newline, so a material with two Custom Code nodes glued the second helper's
  `fn` onto the first's closing brace.

### Erroneous nodes in the graph editor

- The material graph joins `ContentProblems` by node id: offending nodes get a
  red warning icon in the title bar (composed with the sample-variant caret into
  the widget's single header slot) and a hover tooltip with the compiler's
  message. Both ride the node's rebuild hash — they appear when the error lands
  and clear when the material heals.
- The shared tooltip bubble learns text wrapping (360px cap — it was `no_wrap`)
  and an opt-in `TooltipAnchorAbove` marker that centers the bubble over the
  hovered entity's rect instead of beside the cursor.

### Console logging

- Compile sites report to both consoles: validation errors and resolve failures
  as `console_error`, codegen warnings as `console_warn`, category `Material`,
  still once per compile (the uuid key), so nothing floods. `warn!` stays for
  Scene Diagnostics.

### Ctrl+S to save

- The material graph saves on Ctrl+S — the same path as the Apply button, gated
  the same way (graph is the active panel), so the chord never fires while the
  user works in another panel. Sharing the chord with the built-in scene save
  is deliberate: one keystroke saves everything.

### Math-node vectorization

- `material::graph::resolve_math_ranks` — a memoized, cycle-guarded walk: a math
  node's rank is the widest `PinType::vec_rank` among its *connected* dynamic
  inputs (`Float` < `Vec2` < `Vec3` < `Vec4` = `Color`, ties to the earliest pin).
  Latching flows upstream only — a wide consumer on `result` never widens the
  inputs — and `math/lerp`'s `t` stays `Float`, since WGSL's `mix` takes a scalar
  blend factor. Resolution is a pure function of the graph, so nothing is
  serialized and a loaded graph re-derives identical ranks.
- Codegen resolves pin types through the rank map: sources keep their own type and
  `cast_expr` widens at the destination pin, and unwired pins cast their template
  default to the *resolved* type (an unwired `b` on a Vec4 `Add` would otherwise
  compose `vec4 + f32`). Guard literals (`divide`, `modulo`, `log`, `sqrt`,
  `reciprocal`, `asin`, `acos`, `one_minus`, `remap`) splat at the latched rank
  via `Ctx::guard_lit` — deliberately not `cast_expr`, whose Vec4 widening fills
  w with `1.0` and would clamp the guard's last component against 1.0 instead of
  the epsilon. Unconnected graphs compile byte-identical to before.
- Editor surfaces read resolved types: pin colours and groups, inline pin editors
  (a latched Vec4 pin mounts a vec4 editor), connect validation, the auto-wire
  ranking, and the inspector's pin rows.
- Test infrastructure: the shared `ShaderValidator` helper builds once per process
  behind a `OnceLock<Mutex>` — parallel headless apps were starving each other on
  the shared IO task pool and composing against partial shader-library sets.

Fragment shaders only. `CompileResult::vertex_shader` is built and then dropped —
the save path embeds the fragment shader alone and `resolver` never binds a vertex
stage — so the Vegetation domain's wind displacement reaches no GPU today. That is an
unfinished feature rather than a regression, and this change leaves it as it found it.

## AI Assistance

```text
Assisted-by: Claude Opus 5 (claude-opus-5)
Assisted-by: Kimi Code
```

## Checklist

- [x] Code compiles cleanly (`renzora check`)
- [x] All existing tests pass (`renzora test`)
- [x] New tests added (if applicable)
- [x] No unrelated formatting or refactoring changes
- [x] Branch is up to date with `main`
- [ ] I have read every line of this diff and can explain it in review
- [x] Any AI assistance is disclosed above and in an `Assisted-by:` commit trailer

## Testing

`cargo test --profile dist` across all touched crates (`renzora`, `renzora_shader`,
`renzora_shader_editor`, `renzora_material_editor`, `renzora_ember`,
`renzora_blueprint_editor`, `renzora_particle_editor`, `renzora_water`,
`renzora_clouds`, `renzora_terrain`, `renzora_postprocess`) — all suites green:
33 shader-validation tests, 6 resolver end-to-end tests against files on disk (a
broken material is reported, a repair clears it, an untouched material compiles once,
a parameter overflow warns and its repair clears), 2 watcher-filter tests, plus the
crates' existing suites.

Error attribution is covered end to end:

- codegen unit test: a two-node graph's line map covers the emitted ranges, and the
  mutation line attributes to the pin's feeder (also pins the prelude-glue fix).
- validator test: a broken snippet's error carries the exact snippet line, and
  `problems_for_source` resolves it to the node id.
- e2e: the broken-material fixture asserts `line` + `node_id` arrive through the
  embedded artifact's meta, and that the console buffer hears a `Material`
  error naming the broken file.

Vectorization is covered end to end:

- 10 unit tests over `resolve_math_ranks`: latch, no back-latch from downstream,
  widest-wire-wins, detach recompute, scalar never latches, chained propagation,
  cycle guard, `lerp.t` exemption, Vec4/Color tie, serialization round-trip.
- e2e matrix: every math node × every driving rank (`Float`/`Vec2`/`Vec3`/`Vec4`/
  `Color`) × sibling (unconnected / scalar / same-rank) — latch assertion plus
  `ShaderValidator` compile, which is where the rank-aware guards get exercised.
- latch-direction, detach and saved-graph round-trip tests through the validator.

`cargo clippy --profile dist --no-deps` with CI's exact flags (`-D warnings`,
`-A clippy::too_many_arguments`, `-A clippy::type_complexity`) — clean.

Not covered: the tooltip/icon rendering itself (no headless UI lane for the
graph editor); the anchored placement is exercised only by reading the code.

## Screenshots

<img width="729" height="299" alt="image" src="https://github.com/user-attachments/assets/926e59c6-f371-4e39-9f48-ea157c1df985" />
