### PR TITLE
fix(viewport): default pan sensitivity 1.0 → 0.1

### DIFF
--- a/crates/renzora/src/core/viewport_types.rs
+++ b/crates/renzora/src/core/viewport_types.rs
@@ -779,7 +779,7 @@ impl Default for CameraSettingsState {
             move_speed: 10.0,
             look_sensitivity: 0.3,
             orbit_sensitivity: 0.5,
-            pan_sensitivity: 1.0,
+            pan_sensitivity: 0.1,
             zoom_sensitivity: 1.0,
             invert_y: false,
             distance_relative_speed: true,


### PR DESCRIPTION
Sets CameraSettingsState::default().pan_sensitivity to 0.1 so a fresh editor session starts with the slider at the gentler end of the 0.1..=5.0 range.

This is a cherry-pick of 3ef0c13e (which was authored when the pan-sensitivity slider and the runtime wiring were both in flight on the integration branch). On origin/main alone, this commit sets the default but does not change runtime pan behavior — the upstream consumer at renzora_camera/src/lib.rs uses a hardcoded 0.003 * orbit.distance.max(0.5) and does not read pan_sensitivity. The runtime wire-up lives in the camera-polish branch (apply_pan / apply_nav_overlay), which multiplies by pan_sensitivity * 0.004 * slow_mult and pulls pan_sensitivity out of CameraSettingsState via
sync_viewport_settings.

The intended user-facing effect (gentler pan at default) only appears after both this commit and the camera-polish branch have landed on origin/main.

Assisted-by: MiniMax.io (MiniMax-M3)

## Summary

Sets the user-facing default CameraSettingsState::default().pan_sensitivity from 1.0 to 0.1 so a fresh editor session starts with the Pan Sensitivity slider at the bottom of its 0.1..=5.0 range. On its own this only changes the slider's initial display; the runtime pan effect requires the camera-polish branch to land alongside it (which wires pan_sensitivity into the pan math).

## Changes

crates/renzora/src/core/viewport_types.rs: change CameraSettingsState::default().pan_sensitivity from 1.0 to 0.1 (line 782).

## Related Issues

Closes #

## AI Assistance

Did an AI assistant materially help write this change? If so, name the model and
version (one line each) — AI use is welcome, undisclosed AI use is not. Leave
"None" if not applicable. See the [AI Policy](../docs/r1-alpha7/contributing/ai-policy.md).

```text
Assisted-by: MiniMax.io (MiniMax-M3)
```

## Checklist

- [x ] Code compiles cleanly (`renzora check`)
- [x ] All existing tests pass (`renzora test`)
- [x ] New tests added (if applicable)
- [x ] No unrelated formatting or refactoring changes
- [x ] Branch is up to date with `main`
- [x ] I have read every line of this diff and can explain it in review
- [x ] Any AI assistance is disclosed above and in an `Assisted-by:` commit trailer

## Testing

How did you verify this works? Steps to test, screenshots, or test output.

cargo check --profile dist -p renzora -p renzora_camera -p renzora_settings — clean.
cargo test --profile dist -p renzora --lib — 49/49 pass.
cargo test --profile dist -p renzora --lib viewport_types — 7/7 pass including persisted_round_trip_preserves_every_field and persisted_viewport_serde_is_keyed_by_field_name.
Cross-compiled Windows EXE at MD5 0adfa55ac48124f3ec51efeca4e3914d via Docker (this commit + the two sibling branches) opens a fresh project, the Pan Sensitivity slider in Settings → Viewport → Camera reads 0.1 on first launch.

(If applicable — UI changes, rendering changes, etc.)

(n/a — one-line default change, no visual effect)