### PR TITLE
fix(plugin): stub unwind symbols so no_std plugins load again

### DIFF
--- a/crates/renzora_plugin/src/lib.rs
+++ b/crates/renzora_plugin/src/lib.rs
@@ -447,8 +447,11 @@ macro_rules! __plugin_init_body {
     }};
 }
 
-/// Emit the two lang items a `#![no_std]` plugin must define itself: a global
-/// allocator and a panic handler. Call it once, beside [`add!`].
+/// Emit the runtime items a `#![no_std]` plugin must define itself: a global
+/// allocator, a panic handler, and no-op stubs for the two unwind symbols the
+/// precompiled sysroot leaves undefined (`rust_eh_personality`,
+/// `_Unwind_Resume` — see their definitions below). Call it once, beside
+/// [`add!`].
 ///
 /// ```ignore
 /// #![no_std]
@@ -506,6 +509,38 @@ macro_rules! no_std_runtime {
         #[cfg(not(test))]
         #[panic_handler]
         fn __renzora_panic(_: &::core::panic::PanicInfo) -> ! {
+            $crate::no_std_heap::abort()
+        }
+
+        /// Satisfies the `rust_eh_personality` reference that the *precompiled*
+        /// `core` in the sysroot leaves in the cdylib even under
+        /// `panic = "abort"` (the sysroot's `core` is built with unwinding, and
+        /// its objects carry EH frames naming this symbol). The reference is
+        /// harmless at link time but fatal at load time: `dlopen` resolves
+        /// eagerly, the host executable does not export the symbol (and must
+        /// not be asked to — a plugin imports nothing from the host), so every
+        /// `no_std` plugin failed to load with
+        /// `undefined symbol: rust_eh_personality`.
+        ///
+        /// The body is unreachable: with `panic = "abort"` no landing pad is
+        /// ever taken, so the personality routine is never actually called —
+        /// this exists purely so the dynamic linker finds a definition. (The
+        /// real lang item stays nightly-only; defining the *symbol* is stable.)
+        #[cfg(not(test))]
+        #[no_mangle]
+        extern "C" fn rust_eh_personality() {
+            $crate::no_std_heap::abort()
+        }
+
+        /// Same story as `rust_eh_personality`, for the other symbol the
+        /// sysroot's unwind-compiled objects can reference: plugins that pull
+        /// in enough of `alloc`/`core` (e.g. `flock`, `widgets`) carried an
+        /// undefined `_Unwind_Resume`, which libgcc would normally provide.
+        /// Linking libgcc instead would hand the plugin a host dependency for a
+        /// function that `panic = "abort"` guarantees is never reached.
+        #[cfg(not(test))]
+        #[no_mangle]
+        extern "C" fn _Unwind_Resume() {
             $crate::no_std_heap::abort()
         }
     };

--- a/docs/r1-alpha7/extending/standalone-plugins.md
+++ b/docs/r1-alpha7/extending/standalone-plugins.md
@@ -295,6 +295,8 @@ renzora_plugin::no_std_runtime!();
 
 `no_std_runtime!()` supplies the two lang items the standard library would have: a global allocator and a panic handler. The allocator is the **host process's own `malloc`/`free`**, which is deliberate — your plugin is loaded into a running engine that already has an initialised C runtime, so it shares one heap with everything else rather than carrying a second. That also keeps a buffer safe to free after it has crossed the boundary. The panic handler aborts, because there is nothing else it can do.
 
+It also emits no-op stubs for `rust_eh_personality` and `_Unwind_Resume`. The precompiled `core`/`alloc` in the sysroot are built with unwinding, and their objects can leave those symbols undefined in the cdylib even with `panic = "abort"` in the profile. That is harmless at link time but fatal at load time — `dlopen` resolves eagerly and the host does not (and must not) export them — so without the stubs, every `no_std` plugin failed to load with `undefined symbol: rust_eh_personality`. With `panic = "abort"` neither stub can ever actually run; they exist purely so the dynamic linker finds a definition.
+
 The macro expands to nothing when emitting those items would be wrong — under `std`, and under `static_link` where the host binary already provides both — so it is safe to leave in place whatever way the plugin ends up being linked.
 
 Everything else is unchanged: same `add!`, same exports (`renzora_plugin_init`, `renzora_plugin_scope`), same loader path. The engine cannot tell the difference.


### PR DESCRIPTION
Fixes renzora/engine#97

## Problem

Every `no_std` standalone plugin (59 of the 67 in `plugins/`) fails to load on Linux:

```
ERROR renzora_plugin::host::loader: [plugin] libemboss.so failed: could not open:
  .../plugins/.reload/libemboss-0.so: undefined symbol: rust_eh_personality
```

`flock` and `widgets` fail the same way on `_Unwind_Resume`. Only the 8 `std` plugins (lua, audio, http, tracy, …) load, so the editor comes up with no post-process effects and it is easy to misread as a rendering bug.

## Root cause

The precompiled `core`/`alloc` in the rustc 1.95 sysroot are built **with unwinding**, and their objects carry EH frames referencing `rust_eh_personality` (and, for plugins that pull in enough of `alloc`, `_Unwind_Resume`). Setting `panic = "abort"` in the plugin's `dist` profile does not rebuild the sysroot, so the references survive into the cdylib as undefined symbols.

That is harmless at link time, but fatal at load time: `dlopen` resolves eagerly, and the host executable does not export those symbols. Nor should it — the whole premise of the C-ABI plugin system is that a standalone plugin imports *nothing* from the host (and the shipped binaries are UPX-packed, which exports nothing anyway).

## Fix

`no_std_runtime!` now emits no-op `#[no_mangle]` stubs for both symbols, next to the global allocator and panic handler it already emits, under the same `cfg` gates (nothing emitted under `std`, `static_link`, or `cfg(test)`). With `panic = "abort"` no landing pad is ever taken, so neither stub is reachable — they exist purely so the dynamic linker finds a definition. The real `eh_personality` lang item stays nightly-only; defining the *symbol* is stable.

Docs updated: `docs/r1-alpha7/extending/standalone-plugins.md` (the `no_std_runtime!()` section) explains the stubs.

## Verification

- Rebuilt all plugins in the pinned linux container: 67 built, 0 failed, 67 staged.
- `dlopen` smoke test over every staged `.so` in the AppDir: **67/67 load** (before the fix: 8/67, with `nm -D` showing `U rust_eh_personality` in each failing plugin).
- `cargo test --profile dist` in a `no_std` plugin (`emboss`) still passes — the stubs are suppressed under `cfg(test)` like the other emitted items.
