### PR TITLE
fix(solari): tolerate missing SuppressShadowMaps on the first extract

### DIFF
--- a/crates/renzora_solari/src/lib.rs
+++ b/crates/renzora_solari/src/lib.rs
@@ -702,12 +702,20 @@ fn sync_shadow_map_suppression(
 ///
 /// Note this is global rather than per-camera, in the same way Solari's deferred
 /// renderer method is: while it's on, no camera renders shadow maps.
+///
+/// `Option` because the render-world copy of the resource does not exist on the
+/// very first extract: `ExtractResourcePlugin`'s `extract_resource` inserts it
+/// via `Commands`, which only apply at the end of the schedule, so no ordering
+/// within `ExtractSchedule` can make it visible that frame. Suppression is off
+/// by default, so treating the missing frame as "not suppressed" is exactly
+/// right — without the `Option`, Bevy skipped the system with a validation
+/// warning on every boot.
 fn suppress_shadow_maps(
-    suppress: Res<SuppressShadowMaps>,
+    suppress: Option<Res<SuppressShadowMaps>>,
     mut directional: Query<&mut ExtractedDirectionalLight>,
     mut point: Query<&mut ExtractedPointLight>,
 ) {
-    if !suppress.0 {
+    if !suppress.is_some_and(|s| s.0) {
         return;
     }
     for mut light in &mut directional {


### PR DESCRIPTION
Fixes renzora/engine#99

## Problem

Every editor boot logs:

```
WARN bevy_ecs::error::handler: Encountered an error in system `renzora_solari::suppress_shadow_maps`:
Parameter `Res<'_, SuppressShadowMaps>` failed validation: Resource does not exist
```

## Root cause

`suppress_shadow_maps` runs in the render world's `ExtractSchedule` reading `Res<SuppressShadowMaps>`. The render-world copy of that resource is created by `ExtractResourcePlugin`'s `extract_resource` system, which inserts it via `Commands` — and commands only apply at the **end** of the schedule. So on the first extract of the process the resource genuinely does not exist yet, and no ordering constraint within `ExtractSchedule` can fix that. Bevy validates the parameter, warns, and skips the system.

## Fix

Take `Option<Res<SuppressShadowMaps>>` and treat `None` as "not suppressed" — which matches the resource's `Default`, so the skipped frame behaves identically to what a present-but-false resource would do. From the second frame on the resource exists and behavior is unchanged.

The warning was cosmetic (the system was only ever skipped on a frame where it would have done nothing), but it fired on every boot and reads like a real bug.

## Verification

`cargo check --profile dist -p renzora_solari` passes in the pinned linux container; booting the editor no longer logs the warning.
