### PR TITLE
fix(runtime): set a window name so desktops can match the launcher

### DIFF
--- a/crates/renzora_runtime/src/lib.rs
+++ b/crates/renzora_runtime/src/lib.rs
@@ -409,6 +409,13 @@ pub fn add_default_rendering(app: &mut App, is_editor: bool) {
             .set(WindowPlugin {
                 primary_window: Some(Window {
                     title: "Renzora".into(),
+                    // Wayland app_id / X11 WM_CLASS. Desktops match the open
+                    // window to its launcher by this exact string (COSMIC and
+                    // GNOME match it against `<name>.desktop`), so without it
+                    // a pinned dock icon never associates with the running
+                    // editor — the window shows no icon and pinning appears
+                    // broken. Must be set at creation; it is immutable after.
+                    name: Some("renzora-engine".into()),
                     // Initial values — `apply_window_config` overwrites these
                     // from `CurrentProject` once the project is loaded. The
                     // editor draws its own title bar so it wants
@@ -742,6 +749,9 @@ pub fn add_xr_rendering(app: &mut App) {
         .set(WindowPlugin {
             primary_window: Some(Window {
                 title: "Renzora (VR)".into(),
+                // Same launcher association as the desktop window — see the
+                // `name` on the non-XR primary window above.
+                name: Some("renzora-engine".into()),
                 // The desktop window only hosts the spectator mirror — never
                 // block the XR frame loop on the monitor's vsync.
                 present_mode: PresentMode::AutoNoVsync,


### PR DESCRIPTION
Fixes renzora/engine#101

## Problem

The primary window sets only a `title`, never a `name`, so on Wayland the editor window has no `app_id` (and on X11 no meaningful `WM_CLASS`). Desktop shells match a running window to its launcher entry by that exact string — COSMIC and GNOME match it against `<name>.desktop` — so a launcher entry for the editor never associates with the running window: the window shows a generic icon in the dock, and "Pin to Dock" appears broken (the pinned icon and the running window never merge).

## Fix

Set `name: Some("renzora-engine")` on both primary windows (desktop and XR) in `renzora_runtime`. That becomes the Wayland `app_id` and the X11 `WM_CLASS`, matching the `renzora-engine.desktop` + `renzora-engine.png` identity the linux staging already writes into the AppDir (`docker/build-all.sh`). The name must be set at window creation — it is immutable afterwards — which is why this cannot be fixed from configuration or after boot.

## Why `renzora-engine` and not `renzora-editor`

- The desktop identity that already ships is `renzora-engine` (`renzora-engine.desktop`, `Icon=renzora-engine`); matching it means no staged asset needs renaming.
- `renzora-editor` is a binary name, not a product identity. The AppDir carries both executables (`renzora` and `renzora-editor`), and the launcher identity belongs to the product.

## Known limitation (intentional, noted for review)

This window setup lives in `renzora_runtime`, which is shared with the shipped game, so an exported game currently inherits the `renzora-engine` app_id too. That is not a regression — previously there was no app_id at all, and the exporter does not yet generate a `.desktop` for games. When it does, the right refinement is a per-project app_id injected at window creation (e.g. from the baked project config).

## Verification

- `cargo check --profile dist -p renzora_runtime` passes in the pinned linux container.
- On COSMIC (Wayland): with a `renzora-engine.desktop` launcher installed, the running editor window now shows its icon in the dock and pinning associates correctly.
